### PR TITLE
Use ISO8601 date formats

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -44,6 +44,28 @@ require 'passwords'
 
 -- API Endpoints
 -- =============
+local function pg_iso8601(ts)
+    -- postgres dates don't include the "T" time seperator
+    -- they are missing the minutes value on timezones, which JS needs
+    return ts:gsub(' ', 'T'):gsub('([%+%-%d+])$', '%1:00')
+end
+
+local function update_timestamps(object)
+    local timestamp_columns = {}
+    timestamp_columns['created'] = true
+    timestamp_columns['updated'] = true
+    timestamp_columns['lastupdated'] = true
+    timestamp_columns['lastshared'] = true
+    timestamp_columns['firstshared'] = true
+    -- replace all timestamps with an ISO8061 formatted string.
+    for column, value in pairs(object) do
+        -- would be nice to do column:find('_at$')
+        if timestamp_columns[column] then
+            object[column] = pg_iso8601(value)
+        end
+    end
+    return object
+end
 
 app:match('init', '/init', respond_to({
     OPTIONS = cors_options,
@@ -87,11 +109,12 @@ app:match('user', '/users/:username', respond_to({
     OPTIONS = cors_options,
     GET = capture_errors(function (self)
         if not users_match(self) then assert_admin(self) end
-        return jsonResponse(
-            Users:select(
+        user = Users:select(
                 'where username = ? limit 1',
                 self.params.username,
-                { fields = 'username, location, about, created, isadmin, email' })[1])
+                { fields = 'username, location, about, created, isadmin, email' })[1]
+                -- user.created = pg_iso8601(user.created)
+        return jsonResponse(update_timestamps(user))
     end),
 
     DELETE = capture_errors(function (self)
@@ -334,6 +357,10 @@ app:match('projects', '/projects', respond_to({
             local paginator = Projects:paginated(query .. ' order by firstpublished desc', { per_page = self.params.pagesize or 16 })
             local projects = self.params.page and paginator:get_page(self.params.page) or paginator:get_all()
 
+            for _, project in pairs(projects) do
+                update_timestamps(project)
+            end
+
             if self.params.withthumbnail == 'true' then
                 for _, project in pairs(projects) do
                     -- Lazy Thumbnail generation
@@ -394,7 +421,11 @@ app:match('user_projects', '/projects/:username', respond_to({
         local paginator = Projects:paginated(query .. ' order by ' .. order .. ' desc', { per_page = self.params.pagesize or 16 })
         local projects = self.params.page and paginator:get_page(self.params.page) or paginator:get_all()
 
-	-- Lazy Notes generation
+        for _, project in pairs(projects) do
+            update_timestamps(project)
+        end
+
+        -- Lazy Notes generation
         if self.params.updatingnotes == 'true' then
             for _, project in pairs(projects) do
                 if (project.notes == nil or project.notes == '') then
@@ -543,6 +574,7 @@ app:match('project_meta', '/projects/:username/:projectname/metadata', respond_t
         if not project then yield_error(err.nonexistent_project) end
         if not project.ispublic then assert_users_match(self, err.not_public_project) end
 
+        update_timestamps(project)
         return jsonResponse(project)
     end),
     POST = capture_errors(function (self)

--- a/app.lua
+++ b/app.lua
@@ -78,7 +78,7 @@ local function pg_iso8601(timestamp)
     -- they are missing the minutes value on timezones, which JS needs
     -- FROM: 2017-09-01 08:33:50.127-07 TO: 2017-09-01T08:33:50-07:00
     local ts = date(timestamp)
-    return ts:fmt('${iso}' .. ts:fmt('%z'):gsub('(\d\d$)', ':%1'))
+    return ts:fmt('${iso}' .. ts:fmt('%z'):gsub('(%d%d$)', ':%1'))
 end
 
 local function update_timestamps(object)

--- a/app.lua
+++ b/app.lua
@@ -64,20 +64,21 @@ package.loaded.capture_errors = function(fn)
 end
 
 require 'responses'
+local date = require("date")
 
 -- Make cookies persistent
 app.cookie_attributes = function(self)
-    local date = require("date")
     local expires = date(true):adddays(365):fmt("${http}")
     return "Expires=" .. expires .. "; Path=/; HttpOnly; Secure"
 end
 
 -- Database abstractions
-local function pg_iso8601(ts)
+local function pg_iso8601(timestamp)
     -- postgres dates don't include the "T" time seperator
     -- they are missing the minutes value on timezones, which JS needs
-    -- FROM: 2017-09-01 08:33:50.127-07 TO: 2017-09-01T08:33:50.127-07:00
-    return ts:gsub(' ', 'T'):gsub('([%+%-]%d+)$', '%1:00')
+    -- FROM: 2017-09-01 08:33:50.127-07 TO: 2017-09-01T08:33:50-07:00
+    local ts = date(timestamp)
+    return ts:fmt('${iso}' .. ts:fmt('%z'):gsub('(\d\d$)', ':%1'))
 end
 
 local function update_timestamps(object)

--- a/app.lua
+++ b/app.lua
@@ -76,7 +76,8 @@ end
 local function pg_iso8601(ts)
     -- postgres dates don't include the "T" time seperator
     -- they are missing the minutes value on timezones, which JS needs
-    return ts:gsub(' ', 'T'):gsub('([%+%-%d+])$', '%1:00')
+    -- FROM: 2017-09-01 08:33:50.127-07 TO: 2017-09-01T08:33:50.127-07:00
+    return ts:gsub(' ', 'T'):gsub('([%+%-]%d+)$', '%1:00')
 end
 
 local function update_timestamps(object)
@@ -96,10 +97,10 @@ local function update_timestamps(object)
     return object
 end
 
-local original_select = package.loaded.Model.select
-function package.loaded.Model.select(self, query, ...)
-    print('called new select')
-    local result = original_select(self, query, ...)
+-- Have SELECT statements return timestamps from the DB in IS08601
+local original_query = package.loaded.db.query
+function package.loaded.db.query(query, ...)
+    local result = original_query(query, ...)
     for i, obj in ipairs(result) do
         result[i] = update_timestamps(obj)
     end

--- a/app.lua
+++ b/app.lua
@@ -73,26 +73,22 @@ app.cookie_attributes = function(self)
 end
 
 -- Database abstractions
-local function pg_iso8601(timestamp)
-    -- postgres dates don't include the "T" time seperator
-    -- they are missing the minutes value on timezones, which JS needs
-    -- FROM: 2017-09-01 08:33:50.127-07 TO: 2017-09-01T08:33:50-07:00
-    local ts = date(timestamp)
-    return ts:fmt('${iso}' .. ts:fmt('%z'):gsub('(%d%d$)', ':%1'))
-end
-
 local function update_timestamps(object)
+    -- replace all timestamps with an ISO8061 formatted string.
+    -- Postgres dates don't include the "T" time seperator
+    -- They are missing the minutes value on timezones, which JS needs
+    -- FROM: 2017-09-01 08:33:50.127-07 TO: 2017-09-01T08:33:50-07:00
     local timestamp_columns = {}
     timestamp_columns['created'] = true
     timestamp_columns['updated'] = true
     timestamp_columns['lastupdated'] = true
     timestamp_columns['lastshared'] = true
     timestamp_columns['firstshared'] = true
-    -- replace all timestamps with an ISO8061 formatted string.
     for column, value in pairs(object) do
         -- would be nice to do column:find('_at$')
         if timestamp_columns[column] then
-            object[column] = pg_iso8601(value)
+            iso_8601_date = date(value):fmt('${iso}%z'):gsub('(%d%d$)', ':%1')
+            object[column] = iso_8601_date
         end
     end
     return object


### PR DESCRIPTION
Fixes #96
Fixes bromagosa/SnapSite#19

---
This is one idea of how to solve the problem, but it is a tad annoying, IMO. However, it does ensure all responses from the server will have full ISO8601 formatted timestamps that will be accepted by pretty much anything.