### PR TITLE
Adding line to allow snapapps domain on snap cloud.

### DIFF
--- a/cors.lua
+++ b/cors.lua
@@ -47,6 +47,7 @@ domain_allowed['web.media.mit.edu'] = true
 domain_allowed['eliza.csc.ncsu.edu'] = true
 domain_allowed['arena.csc.ncsu.edu'] = true
 domain_allowed['stemc.csc.ncsu.edu'] = true
+domain_allowed['snapapps.fi.ncsu.edu'] = true
 domain_allowed['lambda.cs10.org'] = true
 -- All edX Sites, and test sites
 domain_allowed['courses.edge.edx.org'] = true


### PR DESCRIPTION
This pull request is to get the public domain for NC State's Friday Institute for Educational Innovation allowed on Snap cloud.