### PR TITLE
Improved Error Handling for Updating Project Names and Notes

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -29,6 +29,8 @@ config({'development', 'staging', 'production', 'test'}, {
     discourse_sso_secret = os.getenv('DISCOURSE_SSO_SECRET'),
     worker_connections = os.getenv('WORKER_CONNECTIONS') or 1024,
 
+    stat_arguments = os.getenv('STAT_ARGS') or '-c %Y',
+
     hostname = os.getenv('HOSTNAME') or 'localhost',
     secondary_hostname = os.getenv('SECONDARY_HOSTNAME') or 'localhost',
     maintenance_mode = os.getenv('MAINTENANCE_MODE') or 'false'

--- a/controllers/project.lua
+++ b/controllers/project.lua
@@ -521,7 +521,7 @@ ProjectController = {
                 ispublished = self.params.ispublished or project.ispublished
             })
 
-            if error then yield_error(error) end
+            if error then yield_error({ msg = error, status = 422 }) end
 
             -- save new notes and project name into the project XML
             if new_notes or new_name then

--- a/controllers/project.lua
+++ b/controllers/project.lua
@@ -508,7 +508,7 @@ ProjectController = {
             local new_name = body and body.projectname and body.projectname ~= project.projectname
             local new_notes = body and body.notes and body.notes ~= project.notes
 
-           local result, error = project:update({
+            local result, error = project:update({
                 projectname = new_name and body.projectname or project.projectname,
                 lastupdated = db.format_date(),
                 lastshared = shouldUpdateSharedDate and db.format_date() or nil,

--- a/controllers/project.lua
+++ b/controllers/project.lua
@@ -511,7 +511,7 @@ ProjectController = {
            local result, error = project:update({
                 projectname = new_name and body.projectname or project.projectname,
                 lastupdated = db.format_date(),
-                -- lastshared = shouldUpdateSharedDate and db.format_date() or nil,
+                lastshared = shouldUpdateSharedDate and db.format_date() or nil,
                 firstpublished =
                     project.firstpublished or
                     (self.params.ispublished and db.format_date()) or
@@ -528,8 +528,7 @@ ProjectController = {
                 disk:update_metadata(project.id, project.name, project.notes)
             end
 
-            return okResponse('project ' .. self.params.projectname
-                .. ' updated')
+            return okResponse('project ' .. self.params.projectname .. ' updated')
         end
     },
 

--- a/disk.lua
+++ b/disk.lua
@@ -25,8 +25,13 @@
 
 local xml = require("xml")
 local config = package.loaded.config
+local yield_error = package.loaded.yield_error
 
 local disk = {}
+
+function disk:timestamp_command(dir)
+    return 'stat ' .. config.stat_arguments .. ' ' .. dir .. '/project.xml'
+end
 
 function disk:directory_for_id (id)
     return config.store_path .. '/' .. math.floor(id / 1000) .. '/' .. id
@@ -111,22 +116,33 @@ function disk:update_name(id, name)
     end)
 end
 
+function disk:update_metadata(id, name, notes)
+    self:update_xml(id, function (project)
+        project.name = name
+        local old_notes = xml.find(project, 'notes')
+        old_notes[1] = notes
+    end)
+end
+
 function disk:update_xml(id, update_function)
     local dir = self:directory_for_id(id)
     local project_file = io.open(dir .. '/project.xml', 'r')
     if (project_file) then
-        if pcall(
-            function ()
-                local project = xml.load(project_file:read('*all'))
-                project_file:close()
-                self:backup_project(id)
-                update_function(project)
-                project_file = io.open(dir .. '/project.xml', 'w+')
-                project_file:write(xml.dump(project))
-                project_file:close()
-            end) then
-        else
+        local status, error = pcall(function ()
+            local project = xml.load(project_file:read('*all'))
             project_file:close()
+            project_file = nil
+            self:backup_project(id)
+            update_function(project)
+            project_file = io.open(dir .. '/project.xml', 'w+')
+            project_file:write(xml.dump(project))
+            project_file:close()
+            project_file = nil
+        end)
+        if status then
+        else
+            if project_file then project_file:close() end
+            ngx.log(error)
             yield_error(err.unparseable_xml)
         end
     else
@@ -138,7 +154,7 @@ function disk:get_version_metadata(id, delta)
     local dir = self:directory_for_id(id) .. '/d' .. delta
     local project_file = io.open(dir .. '/project.xml', 'r')
     if (project_file) then
-        local command = io.popen('stat -c %Y ' .. dir .. '/project.xml')
+        local command = io.popen(self:timestamp_command(dir))
         local last_modified = tonumber(command:read())
         command:close()
         return {
@@ -161,10 +177,9 @@ function disk:backup_project(id)
     os.execute('mkdir -p ' .. dir .. '/d-1')
     os.execute('cp -p ' .. dir .. '/*.xml ' .. dir .. '/thumbnail ' ..
         dir .. '/d-1')
-
     -- If the current project was modified more than 12 hours ago,
     -- we save it into the /d-2 folder
-    local command = io.popen('stat -c %Y ' .. dir .. '/project.xml')
+    local command = io.popen(self:timestamp_command(dir))
     local last_modified = tonumber(command:read())
     command:close()
     if (os.time() - last_modified > 43200) then

--- a/models.lua
+++ b/models.lua
@@ -51,7 +51,14 @@ package.loaded.Users = Model:extend('active_users', {
 package.loaded.DeletedUsers = Model:extend('deleted_users')
 
 package.loaded.Projects = Model:extend('active_projects', {
-    primary_key = {'username', 'projectname'}
+    primary_key = {'username', 'projectname'},
+    constraints = {
+        projectname = function (_self, name)
+            if not name or string.len(name) < 1 then
+                return "Project names must have at least one character."
+            end
+        end
+    }
 })
 
 package.loaded.DeletedProjects = Model:extend('deleted_projects', {

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,6 +19,7 @@ env DISCOURSE_SSO_SECRET;
 env ROLLBAR_TOKEN;
 env PROJECT_STORAGE_PATH;
 env MAINTENANCE_MODE;
+env STAT_ARGS;
 
 worker_processes ${{NUM_WORKERS}};
 error_log ${{LOG_DIRECTIVE}};


### PR DESCRIPTION
* Adds a validation such that len(projectnmae) > 0
* Adds some config such that `stat` works on macOS.
    * extracts this into a function for the disk module
    * uses an env variable, which defaults to the GNU stat values.
* Improved error handling in `disk`.
   * If the `pcall` partially fails then recover correctly.
   * The file may have already been closed.
   * Define yield_error (it was not defined)
   * Log the error message from pcall.

**Behavior Changes**:
* Do not update notes or project name if they don't change.
* Update the database before writing files.
    * (This makes the validation easier.)
* Consolidate name and notes update into one write.
    * This wasn't necessary, but seems better than two write cycles.

NOTE: This means we can update the db and have updating the XML fail.
I think this is OK, but if not we can wrap the update in a database
transaction.