### PR TITLE
Rename Deploy script, correct variable ref

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,7 @@
 # ./deploy.sh [BRANCH]
 
 # Allow specifcying a branch or commit to deploy.
-branch=${0-'master'}
+branch=${1-'master'}
 
 echo "Deploying branch: $branch"
 


### PR DESCRIPTION
* `bin/deploy` is nicer than `bin/deploy.sh`
* In ubuntu $0 is the script name, so use $1 for the branch argument reference.

(Not really sure why this seemed to work before?)