### PR TITLE
Add Minor Logged Errors

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -86,7 +86,7 @@ app.cookie_attributes = function(self)
 end
 
 -- Remove the protocol and port from a URL
-function domain_name(url)
+local function domain_name(url)
     if not url then
         return
     end
@@ -115,7 +115,7 @@ app:before_filter(function (self)
 
     -- unescape all parameters
     for k, v in pairs(self.params) do
-        self.params[k] = package.loaded.util.unescape(v or '')
+        self.params[k] = package.loaded.util.unescape(tostring(v))
     end
 
     if self.params.username and self.params.username ~= '' then

--- a/app.lua
+++ b/app.lua
@@ -165,7 +165,7 @@ end
 
 -- Enable the ability to have a maintenance mode
 -- No routes are served, and a generic error is returned.
-if true or config.maintenance_mode == 'true' then
+if config.maintenance_mode == 'true' then
     local msg = 'The Snap!Cloud is currently down for maintenance.'
     app:match('/*', function(self)
         return errorResponse(msg, 500)

--- a/app.lua
+++ b/app.lua
@@ -165,9 +165,9 @@ end
 
 -- Enable the ability to have a maintenance mode
 -- No routes are served, and a generic error is returned.
-if config.maintenance_mode == 'true' then
+if true or config.maintenance_mode == 'true' then
     local msg = 'The Snap!Cloud is currently down for maintenance.'
-    app:get('/*', function(self)
+    app:match('/*', function(self)
         return errorResponse(msg, 500)
     end)
     return app

--- a/helpers.lua
+++ b/helpers.lua
@@ -60,7 +60,8 @@ helpers.normalize_error = function(str)
     local first = str:match("^[^\n]+")
     local result = grammar:match(first) or first
     -- Additionally, trim the fat of standard paths
-    return string.gsub(result, '/usr/local/share/lua/%[NUMBER%]/lapis/', '')
+    return string.gsub(result,
+                       '/usr/local/share/lua/%[NUMBER%]/%a/[%a%.]:%d+:%s', '')
 end
 
 return helpers


### PR DESCRIPTION
We should really use `tostring` so that boolean values are handled correctly.
Prefer `match` over `get` when making routes that can accept requests from multiple verbs