### PR TITLE
New SoundScope URLs

### DIFF
--- a/cors.lua
+++ b/cors.lua
@@ -61,10 +61,12 @@ domain_allowed['preview.edx.org'] = true
 domain_allowed['studio.edge.edx.org'] = true
 domain_allowed['studio.edx.org'] = true
 domain_allowed['edge.edx.org'] = true
--- SoundScope Sites
+-- SoundScope/TuneScope Sites
 domain_allowed['soundscope-website-beta.s3.amazonaws.com/index.html'] = true
 domain_allowed['soundscope-website-beta.s3.amazonaws.com'] = true
 domain_allowed['soundscope-website.web.app'] = true
+domain_allowed['soundscope-website.firebaseapp.com'] = true
+domain_allowed['tunescope.org'] = true
 -- Others
 domain_allowed['www.maketolearn.org'] = true
 domain_allowed['snap.techlit.org'] = true


### PR DESCRIPTION
Updated with new SoundScope URLs: soundscope-website.firebaseapp.com and tunescope.org