### PR TITLE
Handle Users With Duplicate Emails on the forum

### DIFF
--- a/discourse.lua
+++ b/discourse.lua
@@ -68,6 +68,11 @@ app:get('/api/v1/discourse-sso', capture_errors(function(self)
     local user = Users:select('where username = ? limit 1',
             self.session.username,
             { fields = 'id, username, verified, role, email' })[1]
+
+    if user:cannot_access_forum() then
+        yield_error()
+    end
+
     local response_payload = build_payload(user, request_payload.nonce)
     local final_url = create_redirect_url(request_payload.return_sso_url,
                                           response_payload)
@@ -77,25 +82,27 @@ app:get('/api/v1/discourse-sso', capture_errors(function(self)
     return { redirect_to = final_url }
 end))
 
-function create_signature(payload)
+local function create_signature(payload)
     local secret = config.discourse_sso_secret
     return resty_string.to_hex(encoding.hmac_sha256(secret, payload))
 end
 
-function extract_payload(payload)
+local function extract_payload(payload)
     return util.parse_query_string(encoding.decode_base64(payload))
 end
 
 -- Base64 encode the required discourse params.
 -- "require_activation" is a special discourse flag,
 -- for user's whose email is not verified. It enables additional restrictions.
-function build_payload(user, nonce)
+local function build_payload(user, nonce)
     local params = {
         external_id = user.id,
         username = user.username,
-        email = user.email,
+        email = user:discourse_email(),
         require_activation = not user.verified,
         admin = user:isadmin(),
+        moderator = user:ismoderator(),
+        secondary_email = user.email,
         nonce = nonce
     }
     return encoding.encode_base64(util.encode_query_string(params))

--- a/discourse.lua
+++ b/discourse.lua
@@ -78,7 +78,7 @@ app:get('/api/v1/discourse-sso', capture_errors(function(self)
                                           response_payload)
 
     -- don't redirect in development so you don't mess up your forum account.
-    -- if config._name == 'development' then return final_url end
+    if config._name == 'development' then return final_url end
     return { redirect_to = final_url }
 end))
 

--- a/migrations.lua
+++ b/migrations.lua
@@ -34,6 +34,33 @@ local db = require("lapis.db")
 local schema = require("lapis.db.schema")
 local types = schema.types
 
+-- You MUST recreate the views modifying the users table.
+local update_user_views = function ()
+    db.query([[
+        CREATE OR REPLACE VIEW active_users AS (
+            SELECT * FROM users WHERE deleted is null
+        )
+    ]])
+    db.query([[
+        CREATE OR REPLACE VIEW deleted_users AS (
+            SELECT * FROM users WHERE deleted is not null
+        )
+    ]])
+end
+
+local update_project_views = function ()
+    db.query([[
+        CREATE OR REPLACE VIEW active_projects AS (
+            SELECT * FROM projects WHERE deleted is null
+        )
+    ]])
+    db.query([[
+        CREATE OR REPLACE VIEW deleted_projects AS (
+            SELECT * FROM projects WHERE deleted is not null
+        )
+    ]])
+end
+
 return {
     -- TODO: We will eventually create migrations for the other tables.
 
@@ -80,30 +107,12 @@ return {
         schema.add_column('users',
                           'deleted',
                           types.time({ timezone = true, null = true }))
-        db.query([[
-            CREATE VIEW active_users AS (
-                SELECT * FROM users WHERE deleted is null
-            )
-        ]])
-        db.query([[
-            CREATE VIEW deleted_users AS (
-                SELECT * FROM users WHERE deleted is not null
-            )
-        ]])
+        update_user_views()
 
         schema.add_column('projects',
                           'deleted',
                           types.time({ timezone = true, null = true }))
-        db.query([[
-            CREATE VIEW active_projects AS (
-                SELECT * FROM projects WHERE deleted is null
-            )
-        ]])
-        db.query([[
-            CREATE VIEW deleted_projects AS (
-                SELECT * FROM projects WHERE deleted is not null
-            )
-        ]])
+        update_project_views()
     end,
 
     -- Add an editor_ids[] field to collections
@@ -126,9 +135,10 @@ return {
     end,
 
     ['2020-10-22:0'] = function ()
-        schema.add_column('users', 'unique_email', types.text({ null = true }))
+        schema.add_column('users', 'unique_email', types.text({ null = true, unique = true }))
         -- We use an index on *non-unique* emails to be able to search related accounts.
         -- We will rarely query by unique_email and thus no index is necessary.
         schema.create_index('users', 'email', { unique = false })
+        update_user_views()
     end
 }

--- a/migrations.lua
+++ b/migrations.lua
@@ -123,5 +123,12 @@ return {
             { 'updated_at', types.time({ timezone = true }) },
             { 'offense_count', types.integer, { default = 1 } }
         })
+    end,
+
+    ['2020-10-22:0'] = function ()
+        schema.add_column('users', 'unique_email', types.text({ null = true }))
+        -- We use an index on *non-unique* emails to be able to search related accounts.
+        -- We will rarely query by unique_email and thus no index is necessary.
+        schema.create_index('users', 'email', { unique = false })
     end
 }

--- a/models.lua
+++ b/models.lua
@@ -60,15 +60,15 @@ package.loaded.Users = Model:extend('active_users', {
         if self:shares_email_with_others() then
             unique_email = string.gsub(self.email, '@', '+snap-id-' .. self.id .. '@')
         end
-        self:update({ unqiue_email = unique_email })
+        self:update({ unique_email = unique_email })
         return unique_email
     end,
     shares_email_with_others = function (self)
-        email_count = db.interpolate_query('SELECT COUNT(*) FROM useres WHERE email = ?', self.email)
-        return email_count > 1
+        count = package.loaded.Users:count("email like '%'", self.email)
+        return count > 1
     end,
-    can_access_forum = function (self)
-        return not self:isbanned() -- eventually no students.
+    cannot_access_forum = function (self)
+        return self:isbanned() -- eventually no students.
     end
 })
 

--- a/models.lua
+++ b/models.lua
@@ -56,6 +56,9 @@ package.loaded.Users = Model:extend('active_users', {
         return self:ensure_unique_email()
     end,
     ensure_unique_email = function (self)
+        -- If a user is new, then their "unique email" is an unmodified email address.
+        -- When emails are not unique, we will create a new unique email.
+        -- Unqiue emails take the form original-address+snap-id-01234@original.domain
         unique_email = self.email
         if self:shares_email_with_others() then
             unique_email = string.gsub(self.email, '@', '+snap-id-' .. self.id .. '@')


### PR DESCRIPTION
Also puts in place an easy way to block forum logins, bans are now
sort of "synced" -- though banning a user on Snap! doesn't log them out.

* Adds a `unique_email` column to the Users table
* Sets unique_email to the email if it's actually unique
* use's the "+" trick to create a unique email with a Snap! id
* Only creates the unique email when necessary

We still need to sync current forum users by writing a script.