### PR TITLE
Extract out Snap! deploy script.

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -18,15 +18,12 @@ git submodule update --recursive --remote
 
 # Build community site
 pushd site
+echo "Building Comminty Frontend"
+echo
 Snippets/build.sh
 popd
 
-echo "Updating Snap! Release"
-pushd snap
-snap_release=$(git describe --tags $(git rev-list --tags --max-count=1))
-echo "Checking out Snap! ${snap_release}"
-git checkout $snap_release
-popd
+./deploy_snap.sh
 
 source .env
 deploy_sha=$(git rev-parse HEAD)

--- a/bin/deploy_snap.sh
+++ b/bin/deploy_snap.sh
@@ -1,32 +1,39 @@
 #! /usr/bin/env bash
 
-pushd /home/snapCloud/snap/
+base=/home/snapCloud/snap/
 
+pushd $base/snap/;
 echo "Updating Main Snap! Release"
 echo
-pushd snap
 git fetch origin
 snap_release=$(git describe --tags $(git rev-list --tags --max-count=1))
 echo "Checking out Snap! ${snap_release}"
 git checkout $snap_release
-popd
+popd;
+echo
+echo
 
+
+pushd $base/snap-versions/dev;
 echo "Updating DEVELOPMENT Snap!"
 echo
-pushd snap-versions/dev
 git fetch origin
 snap_release="origin/master"
 echo "Checking out Snap! $snap_release"
 git checkout origin/master
 popd;
+echo
+echo
 
 snap_release="v6.0.0" # must be exactly a git tag.
+pushd $base/snap-versions/previous;
 echo "Updating Previous Snap!: $snap_release"
 echo
-pushd snap-versions/previous
 git fetch origin
 echo "Checking out $snap_release"
 git checkout $snap_release
 popd;
+echo
+echo
 
 popd;

--- a/bin/deploy_snap.sh
+++ b/bin/deploy_snap.sh
@@ -35,5 +35,3 @@ git checkout $snap_release
 popd;
 echo
 echo
-
-popd;

--- a/bin/deploy_snap.sh
+++ b/bin/deploy_snap.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+pushd /home/snapCloud/snap/
+
+echo "Updating Main Snap! Release"
+echo
+pushd snap
+git fetch origin
+snap_release=$(git describe --tags $(git rev-list --tags --max-count=1))
+echo "Checking out Snap! ${snap_release}"
+git checkout $snap_release
+popd
+
+echo "Updating DEVELOPMENT Snap!"
+echo
+pushd snap-versions/dev
+git fetch origin
+snap_release="origin/master"
+echo "Checking out Snap! $snap_release"
+git checkout origin/master
+popd;
+
+snap_release="v6.0.0" # must be exactly a git tag.
+echo "Updating Previous Snap!: $snap_release"
+echo
+pushd snap-versions/previous
+git fetch origin
+echo "Checking out $snap_release"
+git checkout $snap_release
+popd;
+
+popd;

--- a/bin/renew-certs.sh
+++ b/bin/renew-certs.sh
@@ -5,5 +5,6 @@
 # https://dev-notes.eu/2018/05/set-up-an-automatic-letsencrypt-renewal-cronjob/
 
 pushd ~/
-/usr/bin/perl -e 'sleep int(rand(3600))' && certbot renew --config-dir lets-encrypt --logs-dir lets-encrypt --work-dir lets-encrypt --deploy-hook snapCloud/bin/deploy_certs.sh
+# /usr/bin/perl -e 'sleep int(rand(3600))' && # DISABLED SLEEP FOR NOW.
+certbot renew --config-dir lets-encrypt --logs-dir lets-encrypt --work-dir lets-encrypt --deploy-hook snapCloud/bin/deploy_certs.sh
 popd


### PR DESCRIPTION
Mostly for convenience.
Updates all 3 copies of Snap!

* main to latest tag.
* dev/ to jens' master
* previous/ to the version specified, currently 6.0.0