### PR TITLE
Fixed MacOS install scripts with luarocks and gcc_version variable syntax

### DIFF
--- a/bin/luarocks-install-macos.sh
+++ b/bin/luarocks-install-macos.sh
@@ -10,6 +10,7 @@ LUA_DIR="/usr/local/opt/lua@5.1"
 OPENSSL_BREW='/usr/local/opt/openssl/'
 
 echo 'Installing lua dependencies'
-$gcc_version='gcc-10'
+gcc_version='gcc-10'
 # For some reason luarocks needs both directories specified...
+# Set by parameter the Lua version used (currently 5.1)
 luarocks install --lua-dir=$LUA_DIR snap-cloud-beta-0.rockspec OPENSSL_DIR=$OPENSSL_BREW CRYPTO_DIR=$OPENSSL_BREW CC=$gcc_version LD=$gcc_version $@

--- a/bin/setup_osx.sh
+++ b/bin/setup_osx.sh
@@ -24,7 +24,7 @@ fi
 # Install basic dependencies via brew
 # Note that we must use lua 5.1, not 5.2 or 5.3
 echo 'Installing lua and postgres'
-brew install lua@5.1 postgres pcre
+brew install lua@5.1 luarocks postgres pcre
 
 echo 'Installing OpenResty'
 brew tap denji/nginx
@@ -35,7 +35,10 @@ ln -s /usr/local/opt/openresty/bin/openresty /usr/local/opt/openresty/bin/nginx
 
 echo 'Adding luarocks path info to bashrc'
 echo "" >> ~/.bashrc
-echo "# Luarocks 3 and Lua 5.1 tools (added by snapCloud." >> ~/.bashrc
+echo "# Luarocks 3 and Lua 5.1 tools (added by snapCloud)." >> ~/.bashrc
 echo $(luarocks path --lua-version 5.1) >> ~/.bashrc
 
 bin/luarocks-install-macos.sh;
+
+echo "Prerequisites installed."
+echo "Please follow all instructions after 'Setting up the database' in INSTALL.md"


### PR DESCRIPTION
Added in the missing "luarocks" brew install library and more message informing the developer of success in installation

Fixed a variable declaration, where in Macs variable declarations don't need "$", only evaluation