### PR TITLE
Change SameSite to Lax during Development in app.lua

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,12 +14,6 @@ $ git clone --recursive https://github.com/bromagosa/snapCloud.git
 
 ## Development
 
-### NOTE: Browser Selection for Cookies to work
-
-Chromium-based browsers will not save the cookies of your login session during the development of Snap!Cloud. They will work on the deployed wesite.
-
-As a result, it is recommended to use Firefox or Safari to load pages during development, and never Chromium browsers (Chrome, Opera, New Microsoft Edge, etc.).
-
 ### Steps to look into
 
 When developing on Snap!Cloud on your local machine, the following sections are important:

--- a/app.lua
+++ b/app.lua
@@ -74,7 +74,7 @@ require 'responses'
 app.cookie_attributes = function(self)
     local expires = date(true):adddays(365):fmt("${http}")
     local secure = config._name ~= 'development' and " Secure" or ""
-    return "Expires=" .. expires .. "; Path=/; HttpOnly; SameSite=None;" .. secure
+    return "Expires=" .. expires .. "; Path=/; HttpOnly; SameSite=Lax;" .. secure
 end
 
 -- Remove the protocol and port from a URL

--- a/app.lua
+++ b/app.lua
@@ -73,8 +73,13 @@ require 'responses'
 -- Make cookies persistent
 app.cookie_attributes = function(self)
     local expires = date(true):adddays(365):fmt("${http}")
-    local secure = config._name ~= 'development' and " Secure" or ""
-    return "Expires=" .. expires .. "; Path=/; HttpOnly; SameSite=Lax;" .. secure
+    local secure = " " .. "Secure"
+    local sameSite = "None"
+    if (config._name == 'development') then
+        secure = ""
+        sameSite = "Lax"
+    end
+    return "Expires=" .. expires .. "; Path=/; HttpOnly; SameSite=" .. sameSite .. ";" .. secure
 end
 
 -- Remove the protocol and port from a URL


### PR DESCRIPTION

Related Issue: https://github.com/snap-cloud/snapCloud/issues/277

Confirmed that setting the SameCookie attribute to "Lax" fixes the issue for development

"None" works in the deployed website (for some reason)

Tested on Chrome and Opera (both Chromium browsers)
