### PR TITLE
Sigh, just always renew and deploy certs on app deploy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -23,6 +23,8 @@ echo
 Snippets/build.sh
 popd
 
+./renew-certs.sh
+./deploy_certs.sh
 ./deploy_snap.sh
 
 
@@ -68,7 +70,7 @@ curl -XPOST https://hooks.slack.com/workflows/T02BLN36L/A01PUMAEUPR/344588914394
 
 
 # Always update the letsencrypt script incase it changes.
-cp bin/deploy_certs.sh ../lets-encrypt/renewal-hooks/deploy/1-deploy.sh
+cp ./deploy_certs.sh ../lets-encrypt/renewal-hooks/deploy/1-deploy.sh
 
 # The cloud user only has the ability to restart this service.
 echo 'Restarting snapcloud daemon'


### PR DESCRIPTION
Not sure what's up with the letsencrypt not correctly calling the deploy_certs script...
But in any event this should help out.