### PR TITLE
Fix the shares_email_with_others function

### DIFF
--- a/controllers/user.lua
+++ b/controllers/user.lua
@@ -352,7 +352,7 @@ UserController = {
                 end
 
                 local salt = secure_salt()
-                Users:create({
+                local user = Users:create({
                     created = db.format_date(),
                     username = self.params.username,
                     salt = salt,
@@ -362,6 +362,7 @@ UserController = {
                     verified = false,
                     role = 'standard'
                 })
+                user.ensure_unique_email()
 
                 -- Create a verify_user-type token and send an email to the user
                 -- asking to verify the account.

--- a/models.lua
+++ b/models.lua
@@ -67,8 +67,8 @@ package.loaded.Users = Model:extend('active_users', {
         return unique_email
     end,
     shares_email_with_others = function (self)
-        count = package.loaded.Users:count("email like '%'", self.email)
-        return count > 1
+        count = package.loaded.Users:count("unique_email ilike ?", self.email)
+        return count > 0
     end,
     cannot_access_forum = function (self)
         return self:isbanned() or self.validated == false


### PR DESCRIPTION
* This was not escaping correctly. :(
* Previously if a user made 2 accounts with the same email, they both got a unique email
* NOW the first account gets a "normal" email, and the second account gets a unique one.
* Calls `self:ensure_unique_email()` on User:create instead of just discourse sign in...