### PR TITLE
Bulk account creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ torbulkexitlist
 .env
 setenv
 logs
+tmp/*
 nginx.conf.compiled
 
 .htpasswd

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,6 +70,15 @@ Additional Lua packages you need for the Snap!Cloud to work properly are the Bcr
 
 All Lua dependencies are contained in the rockspec.
 
+### Note About `git` protocols
+
+Some rocks still use the `git://` protocol, which GitHub no longer accepts.
+The 'easy' was to get around this is to use a global git configuration:
+
+```
+$ git config --global url."https://github".insteadOf git://github
+```
+
 ### Luarocks macOS
 
 `luarocks` will default to lua 5.3, which we do not use. Instead, `bin/luarocks-macos` "wraps" luarocks with our defaults,
@@ -83,15 +92,6 @@ $ bin/luarocks-macos install snapcloud-dev-0.rockspec
 
 ```
 # luarocks install snapcloud-dev-0.rockspec
-```
-
-#### Note About `git` protocols
-
-Some rocks still use the `git://` protocol, which GitHub no longer accepts.
-The 'easy' was to get around this is to use a global git configuration:
-
-```
-# git config --global url."https://github".insteadOf git://github
 ```
 
 ### Authbind

--- a/api.lua
+++ b/api.lua
@@ -27,6 +27,7 @@ local api_version = 'v1'
 local app = package.loaded.app
 local capture_errors = package.loaded.capture_errors
 local yield_error = package.loaded.yield_error
+local json_params = package.loaded.json_params
 local respond_to = package.loaded.respond_to
 
 require 'validation'
@@ -163,6 +164,11 @@ app:match(api_route('users/:username/resendverification'), respond_to({
 app:match(api_route('users/:username/follow'), respond_to({
     POST = UserController.follow,
     DELETE = UserController.unfollow
+}))
+
+
+app:match(api_route('users/create_many'), respond_to({
+    POST = json_params(UserController.create_many),
 }))
 
 -- Zombies

--- a/bin/lapis-migrate
+++ b/bin/lapis-migrate
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
 
 # A simple wrapper because `lapis migrate` is broken.
+source .env
 lapis exec 'require("lapis.db.migrations").run_migrations(require("migrations"))' --trace

--- a/bin/luarocks-macos
+++ b/bin/luarocks-macos
@@ -7,7 +7,7 @@
 LUA_DIR="/usr/local/opt/lua@5.1"
 # Needed for lapis
 OPENSSL_BREW='/usr/local/opt/openssl/'
-gcc_version='gcc-12'
+gcc_version='gcc-10'
 
 # For some reason luarocks needs both directories specified...
 # Set by parameter the Lua version used (currently 5.1)
@@ -16,6 +16,6 @@ luarocks --lua-version=5.1 --lua-dir=$LUA_DIR --dev \
   CRYPTO_DIR=$OPENSSL_BREW \
   CC=$gcc_version \
   LD=$gcc_version \
-  CFLAGS='--std=c++14' \
+  CPPFLAGS='--std=c++14' \
   STDCPP_LIBDIR=/usr/local/Cellar/gcc/12.2.0/lib/gcc/current/ \
   $@;

--- a/controllers/user.lua
+++ b/controllers/user.lua
@@ -434,26 +434,23 @@ UserController = {
     end),
     create_many = capture_errors(function (self)
         -- For consistency, all users will be created or NONE will be created.
-        -- rate_limit(self)
         assert_user_can_create_accounts(self)
         local users = self.params.users
         if not users then
             yield_error('Malformed JSON Provided.')
         end
 
-        local expected, created, errors = #users, 0, 0
-        local users_list = nil
-        if expected > 50 then yield_error('Please limit bulk creation to 50 users.') end
+        if #users > 50 then yield_error('Please limit bulk creation to 50 users.') end
 
-        -- Assert no users exist.
         local usernames = {}
         for _, user in pairs(users) do
             table.insert(usernames, util.trim(tostring(user.username)))
         end
 
+    -- Assert no users exist.
         local existing_users = AllUsers:find_all(usernames, 'username', { fields = 'username' })
         if #existing_users > 0 then
-            local usernames = {}
+            usernames = {}
             local msg =
                  "No user accounts created! " ..
                 #existing_users .. " users already exist. Please provide new usernames for the following users."
@@ -463,30 +460,31 @@ UserController = {
             return errorResponse({ error = msg, users = usernames }, 400)
         end
 
-        -- Build a large table to run a single INSERT query
-        -- for _, user in pairs(users) do
-        --     debug_print(user)
-        --     user.username = util.trim(tostring(user.username))
-        --     user.password = util.trim(tostring(user.password))
-        --     user.email = user.email or self.current_user.email
-        --     local is_valid = validate.validate(user, User.validations)
-        --     debug_print('IS VALID? ' .. is_valid)
-        --     user.created = db.format_date()
-        --     user.salt = secure_salt()
-        -- end
+        -- wrap all user creations in a transaction. No partial completions.
+        db.query('BEGIN;')
+        for _, user in pairs(users) do
+            user.username = util.trim(tostring(user.username))
+            user.password = util.trim(tostring(user.password))
+            user.email = user.email or self.current_user.email
+            -- TODO: This doesn't reveal which record has an invalid value...
+            validate.assert_valid(user, Users.validations)
 
-        debug_print(users)
-        -- local user = Users:create({
-        --
-        --     password = hash_password(self.params.password, salt),
-        --     verified = false,
-        --     role = 'standard'
-        -- })
-        if false then
-            return errorResponse('Some accounts not created')
+            user.created = db.format_date()
+            user.salt = secure_salt()
+            user.password = hash_password(user.password, user.salt)
+            user.verified = true
+            user.role = 'standard'
+            user.creator_id = self.current_user.id
+            local result = Users:create(user)
+            if not result then
+                db.query('ROLLBACK;')
+                return errorResponse('User ' .. user.username .. ' errored on creation.')
+            end
         end
+        local result = db.query('COMMIT;')
+
         return jsonResponse({
-            message = created .. ' ussers created.',
+            message = #usernames .. ' ussers created.',
             users = usernames
         })
     end),

--- a/controllers/user.lua
+++ b/controllers/user.lua
@@ -28,9 +28,11 @@ local yield_error = package.loaded.yield_error
 local capture_errors = package.loaded.capture_errors
 local socket = require('socket')
 local app = package.loaded.app
+local json = require('cjson')
 
 local Users = package.loaded.Users
 local DeletedUsers = package.loaded.DeletedUsers
+local AllUsers = package.loaded.AllUsers
 local Projects = package.loaded.Projects
 local Collections = package.loaded.Collections
 local Tokens = package.loaded.Tokens
@@ -428,6 +430,64 @@ UserController = {
                 'account within the next 3 days.\nYou can now log in.',
             title = 'Account Created',
             redirect = self:build_url('login')
+        })
+    end),
+    create_many = capture_errors(function (self)
+        -- For consistency, all users will be created or NONE will be created.
+        -- rate_limit(self)
+        assert_user_can_create_accounts(self)
+        local users = self.params.users
+        if not users then
+            yield_error('Malformed JSON Provided.')
+        end
+
+        local expected, created, errors = #users, 0, 0
+        local users_list = nil
+        if expected > 50 then yield_error('Please limit bulk creation to 50 users.') end
+
+        -- Assert no users exist.
+        local usernames = {}
+        for _, user in pairs(users) do
+            table.insert(usernames, util.trim(tostring(user.username)))
+        end
+
+        local existing_users = AllUsers:find_all(usernames, 'username', { fields = 'username' })
+        if #existing_users > 0 then
+            local usernames = {}
+            local msg =
+                 "No user accounts created! " ..
+                #existing_users .. " users already exist. Please provide new usernames for the following users."
+            for _, user in pairs(existing_users) do
+                table.insert(usernames, user.username)
+            end
+            return errorResponse({ error = msg, users = usernames }, 400)
+        end
+
+        -- Build a large table to run a single INSERT query
+        -- for _, user in pairs(users) do
+        --     debug_print(user)
+        --     user.username = util.trim(tostring(user.username))
+        --     user.password = util.trim(tostring(user.password))
+        --     user.email = user.email or self.current_user.email
+        --     local is_valid = validate.validate(user, User.validations)
+        --     debug_print('IS VALID? ' .. is_valid)
+        --     user.created = db.format_date()
+        --     user.salt = secure_salt()
+        -- end
+
+        debug_print(users)
+        -- local user = Users:create({
+        --
+        --     password = hash_password(self.params.password, salt),
+        --     verified = false,
+        --     role = 'standard'
+        -- })
+        if false then
+            return errorResponse('Some accounts not created')
+        end
+        return jsonResponse({
+            message = created .. ' ussers created.',
+            users = usernames
         })
     end),
     become = capture_errors(function (self)

--- a/migrations.lua
+++ b/migrations.lua
@@ -1,7 +1,7 @@
 -- Database migrations
 -- ===================
 --
--- Run migrations by running bin/migrations.sh
+-- Run migrations by running bin/lapis-migrate
 --
 -- Do not modify a migration once it has been run or commited!
 -- To change what a migration does, create a new one.
@@ -283,5 +283,20 @@ return {
             types.integer({ default = 0 })
         )
         update_user_views()
+    end,
+
+    -- Add columns to users to support teacher accounts.
+    ['2023-03-14:0'] = function()
+        -- this is likely temporary, but is a starting point.
+        schema.add_column(
+            'users',
+            'is_teacher',
+            types.boolean({ default = false })
+        )
+        schema.add_column(
+            'users',
+            'creator_id',
+            types.foreign_key({ null = true })
+        )
     end
 }

--- a/migrations.lua
+++ b/migrations.lua
@@ -298,5 +298,9 @@ return {
             'creator_id',
             types.foreign_key({ null = true })
         )
+    end,
+
+    ['2023-03-14:1'] = function()
+        update_user_views()
     end
 }

--- a/models.lua
+++ b/models.lua
@@ -85,6 +85,10 @@ package.loaded.Users = Model:extend('active_users', {
     isbanned = function (self)
         return self.role == 'banned'
     end,
+    is_teacher = function (self)
+        -- This is likely to get more complex in the future.
+        return self.is_teacher
+    end,
     has_min_role = function (self, expected_role)
         return package.loaded.Users.roles[self.role] >=
             package.loaded.Users.roles[expected_role]
@@ -136,6 +140,12 @@ package.loaded.Users = Model:extend('active_users', {
     end
 })
 
+package.loaded.Users.validations = {
+    { 'username', exists = true, min_length = 4, max_length = 200 },
+    { 'password', exists = true, min_length = 6 },
+    { 'email', exists = true, min_length = 5 }
+}
+
 package.loaded.Users.roles = {
     admin = 4,
     moderator = 3,
@@ -145,6 +155,9 @@ package.loaded.Users.roles = {
 }
 
 package.loaded.DeletedUsers = Model:extend('deleted_users')
+
+-- Used for querires across the entire users table.
+package.loaded.AllUsers = Model:extend('users')
 
 package.loaded.Projects = Model:extend('active_projects', {
     type = 'project',

--- a/responses.lua
+++ b/responses.lua
@@ -56,11 +56,16 @@ rawResponse = function (contents)
 end
 
 errorResponse = function (err, status)
+    if (type(err) == 'table') then
+        response = err
+    else
+        response = { errors = { err } }
+    end
     return {
         layout = false,
         status = status or 500,
         readyState = 4,
-        json = { errors = { err } }
+        json = response
     }
 end
 

--- a/validation.lua
+++ b/validation.lua
@@ -115,6 +115,10 @@ err = {
         { msg = 'Please use the Snap! site, not scripts.', status = 409 },
     tor_not_allowed =
         { msg = 'Sorry. We cannot let you use Tor for that.', status = 403 },
+    teacher_account_required = {
+        msg = 'You must be verified as a teacher to perfom this action.',
+        status = 403
+    }
 }
 
 assert_all = function (assertions, self)
@@ -241,6 +245,15 @@ assert_users_have_email = function (self, message)
     end
 end
 
+assert_user_can_create_accounts = function(self)
+    if self.current_user:isadmin() then return end
+    if not self.current_user.verified then
+        yield_error(err.nonvalidated_user)
+    end
+    if not self.current_user:is_teacher() then
+        yield_error(err.teacher_account_required)
+    end
+end
 
 -- Projects and Collections
 
@@ -349,7 +362,7 @@ end
 
 can_edit_collection = function (self, collection)
     -- Users can edit their own collections
-    return (self.current_user ~= nil) and 
+    return (self.current_user ~= nil) and
         ((collection.creator_id == self.current_user.id) or
         is_editor(self, collection))
 end

--- a/writeguardmuter.lua
+++ b/writeguardmuter.lua
@@ -37,6 +37,7 @@ local selectors = {
     'err', 'assert_all', 'assert_logged_in', 'assert_role',
     'assert_has_one_of_roles', 'assert_admin', 'assert_can_set_role',
     'users_match', 'assert_users_match', 'assert_user_exists',
+    'assert_user_can_create_accounts',
     'assert_users_have_email', 'assert_project_exists', 'check_token',
     'create_token', 'can_edit_collection', 'assert_collection_exists',
     'assert_can_view_collection', 'assert_can_add_project_to_collection',


### PR DESCRIPTION
Support Bulk Account Creation for logged in users. 

POST format:

```json:
{ 
"users": [
{
"username": "user1", "password": "password1", "email": 'OPTIONAL'
},
{ ...}
]
}
```

If an email is not provided, then the current user's email address is used. 
To be able to use this route, you must either be an admin OR have `is_teacher` set to true on your account.
This flag is probably not a permanent solution, but could work to solve immediate issues. 


* users are auto marked as verified, and we skip a welcome email
* We do track who created the user
* no UI for any of this right now. 
* We check to make sure no users exist first, otherwise use a transaction when creating accounts.