### PR TITLE
Cleanup Database configuration

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -238,7 +238,7 @@ SnapCloud will read variables from a file `.env` which contains contains data sp
 
 ```sh
 export LAPIS_ENVIRONMENT=production
-export DATABASE_URL=127.0.0.1
+export DATABASE_HOST=127.0.0.1
 export DATABASE_PORT=5432
 export DATABASE_USERNAME=cloud
 export DATABASE_PASSWORD=snap-cloud-password

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -238,7 +238,8 @@ SnapCloud will read variables from a file `.env` which contains contains data sp
 
 ```sh
 export LAPIS_ENVIRONMENT=production
-export DATABASE_URL=127.0.0.1:5432
+export DATABASE_URL=127.0.0.1
+export DATABASE_PORT=5432
 export DATABASE_USERNAME=cloud
 export DATABASE_PASSWORD=snap-cloud-password
 export DATABASE_NAME=snapcloud

--- a/bin/dump_schema.sh
+++ b/bin/dump_schema.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "Please provide the password for the cloud database owner"
-pg_dump -W -Fp -s -h localhost -U $DATABASE_USERNAME -d $DATABASE_NAME > cloud.sql

--- a/bin/lapis-migrate
+++ b/bin/lapis-migrate
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
-# A simple wrapper because `lapis migrate` is broken.
+# Wrap `lapis migrate` to ensure we always dump the current schema to cloud.sql
 source .env
-lapis exec 'require("lapis.db.migrations").run_migrations(require("migrations"))' --trace
+lapis migrate
+if [ $LAPIS_ENVIRONMENT == 'development']; then
+  echo 'Dumping schema to cloud.sql.';
+  DB_USER="${DATABASE_USER:-$USER}"
+  DB_HOST="${DATABASE_HOST:-localhost}"
+  pg_dump --schema-only --no-owner --create -x -h $DB_HOST -U $DB_USER -d $DATABASE_NAME > cloud.sql;
+  pg_dump -x --no-owner --data-only -t lapis_migrations -h $DB_HOST -U $DB_USER -d $DATABASE_NAME | grep -v "^SET*" >> cloud.sql
+fi

--- a/cloud.sql
+++ b/cloud.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.5 (Ubuntu 10.5-1.pgdg16.04+1)
--- Dumped by pg_dump version 10.5 (Ubuntu 10.5-1.pgdg16.04+1)
+-- Dumped from database version 14.7 (Homebrew)
+-- Dumped by pg_dump version 14.7 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -12,34 +12,53 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+-- Name: snapcloud; Type: DATABASE; Schema: -; Owner: -
 --
 
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+CREATE DATABASE snapcloud WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE = 'C';
+
+
+\connect snapcloud
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+-- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
 --
 
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
 
 
 --
--- Name: dom_username; Type: DOMAIN; Schema: public; Owner: cloud
+-- Name: dom_username; Type: DOMAIN; Schema: public; Owner: -
 --
 
 CREATE DOMAIN public.dom_username AS text;
 
 
-ALTER DOMAIN public.dom_username OWNER TO cloud;
-
 --
--- Name: snap_user_role; Type: TYPE; Schema: public; Owner: cloud
+-- Name: snap_user_role; Type: TYPE; Schema: public; Owner: -
 --
 
 CREATE TYPE public.snap_user_role AS ENUM (
@@ -51,10 +70,8 @@ CREATE TYPE public.snap_user_role AS ENUM (
 );
 
 
-ALTER TYPE public.snap_user_role OWNER TO cloud;
-
 --
--- Name: expire_token(); Type: FUNCTION; Schema: public; Owner: cloud
+-- Name: expire_token(); Type: FUNCTION; Schema: public; Owner: -
 --
 
 CREATE FUNCTION public.expire_token() RETURNS trigger
@@ -67,14 +84,12 @@ END;
 $$;
 
 
-ALTER FUNCTION public.expire_token() OWNER TO cloud;
-
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: cloud
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.projects (
@@ -92,10 +107,8 @@ CREATE TABLE public.projects (
 );
 
 
-ALTER TABLE public.projects OWNER TO cloud;
-
 --
--- Name: active_projects; Type: VIEW; Schema: public; Owner: cloud
+-- Name: active_projects; Type: VIEW; Schema: public; Owner: -
 --
 
 CREATE VIEW public.active_projects AS
@@ -114,10 +127,8 @@ CREATE VIEW public.active_projects AS
   WHERE (projects.deleted IS NULL);
 
 
-ALTER TABLE public.active_projects OWNER TO cloud;
-
 --
--- Name: users; Type: TABLE; Schema: public; Owner: cloud
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.users (
@@ -131,14 +142,14 @@ CREATE TABLE public.users (
     location text,
     verified boolean,
     role public.snap_user_role DEFAULT 'standard'::public.snap_user_role,
-    deleted timestamp with time zone
+    deleted timestamp with time zone,
+    unique_email text,
+    bad_flags integer DEFAULT 0 NOT NULL
 );
 
 
-ALTER TABLE public.users OWNER TO cloud;
-
 --
--- Name: active_users; Type: VIEW; Schema: public; Owner: cloud
+-- Name: active_users; Type: VIEW; Schema: public; Owner: -
 --
 
 CREATE VIEW public.active_users AS
@@ -152,15 +163,102 @@ CREATE VIEW public.active_users AS
     users.location,
     users.verified,
     users.role,
-    users.deleted
+    users.deleted,
+    users.unique_email,
+    users.bad_flags
    FROM public.users
   WHERE (users.deleted IS NULL);
 
 
-ALTER TABLE public.active_users OWNER TO cloud;
+--
+-- Name: banned_ips; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.banned_ips (
+    ip text NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    offense_count integer DEFAULT 0 NOT NULL
+);
+
 
 --
--- Name: count_recent_projects; Type: VIEW; Schema: public; Owner: cloud
+-- Name: collection_memberships; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.collection_memberships (
+    id integer NOT NULL,
+    collection_id integer NOT NULL,
+    project_id integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    user_id integer NOT NULL
+);
+
+
+--
+-- Name: collection_memberships_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.collection_memberships_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: collection_memberships_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.collection_memberships_id_seq OWNED BY public.collection_memberships.id;
+
+
+--
+-- Name: collections; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.collections (
+    id integer NOT NULL,
+    name text NOT NULL,
+    creator_id integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    description text,
+    published boolean DEFAULT false NOT NULL,
+    published_at timestamp with time zone,
+    shared boolean DEFAULT false NOT NULL,
+    shared_at timestamp with time zone,
+    thumbnail_id integer,
+    editor_ids integer[],
+    free_for_all boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: collections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.collections_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: collections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.collections_id_seq OWNED BY public.collections.id;
+
+
+--
+-- Name: count_recent_projects; Type: VIEW; Schema: public; Owner: -
 --
 
 CREATE VIEW public.count_recent_projects AS
@@ -169,10 +267,8 @@ CREATE VIEW public.count_recent_projects AS
   WHERE (projects.lastupdated > (('now'::text)::date - '1 day'::interval));
 
 
-ALTER TABLE public.count_recent_projects OWNER TO cloud;
-
 --
--- Name: deleted_projects; Type: VIEW; Schema: public; Owner: cloud
+-- Name: deleted_projects; Type: VIEW; Schema: public; Owner: -
 --
 
 CREATE VIEW public.deleted_projects AS
@@ -191,10 +287,8 @@ CREATE VIEW public.deleted_projects AS
   WHERE (projects.deleted IS NOT NULL);
 
 
-ALTER TABLE public.deleted_projects OWNER TO cloud;
-
 --
--- Name: deleted_users; Type: VIEW; Schema: public; Owner: cloud
+-- Name: deleted_users; Type: VIEW; Schema: public; Owner: -
 --
 
 CREATE VIEW public.deleted_users AS
@@ -208,15 +302,85 @@ CREATE VIEW public.deleted_users AS
     users.location,
     users.verified,
     users.role,
-    users.deleted
+    users.deleted,
+    users.unique_email,
+    users.bad_flags
    FROM public.users
   WHERE (users.deleted IS NOT NULL);
 
 
-ALTER TABLE public.deleted_users OWNER TO cloud;
+--
+-- Name: featured_collections; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.featured_collections (
+    collection_id integer NOT NULL,
+    page_path text NOT NULL,
+    type text NOT NULL,
+    "order" integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
 
 --
--- Name: projects_id_seq; Type: SEQUENCE; Schema: public; Owner: cloud
+-- Name: flagged_projects; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.flagged_projects (
+    id integer NOT NULL,
+    flagger_id integer NOT NULL,
+    project_id integer NOT NULL,
+    reason text NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    notes text
+);
+
+
+--
+-- Name: flagged_projects_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.flagged_projects_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: flagged_projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.flagged_projects_id_seq OWNED BY public.flagged_projects.id;
+
+
+--
+-- Name: followers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.followers (
+    follower_id integer NOT NULL,
+    followed_id integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: lapis_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.lapis_migrations (
+    name character varying(255) NOT NULL
+);
+
+
+--
+-- Name: projects_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.projects_id_seq
@@ -227,17 +391,15 @@ CREATE SEQUENCE public.projects_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.projects_id_seq OWNER TO cloud;
-
 --
--- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: cloud
+-- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 
 
 --
--- Name: recent_projects_2_days; Type: VIEW; Schema: public; Owner: cloud
+-- Name: recent_projects_2_days; Type: VIEW; Schema: public; Owner: -
 --
 
 CREATE VIEW public.recent_projects_2_days AS
@@ -246,10 +408,8 @@ CREATE VIEW public.recent_projects_2_days AS
   WHERE (projects.lastupdated > (('now'::text)::date - '2 days'::interval));
 
 
-ALTER TABLE public.recent_projects_2_days OWNER TO cloud;
-
 --
--- Name: remixes; Type: TABLE; Schema: public; Owner: cloud
+-- Name: remixes; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.remixes (
@@ -259,10 +419,8 @@ CREATE TABLE public.remixes (
 );
 
 
-ALTER TABLE public.remixes OWNER TO cloud;
-
 --
--- Name: tokens; Type: TABLE; Schema: public; Owner: cloud
+-- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tokens (
@@ -273,10 +431,8 @@ CREATE TABLE public.tokens (
 );
 
 
-ALTER TABLE public.tokens OWNER TO cloud;
-
 --
--- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: cloud
+-- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.users_id_seq
@@ -287,31 +443,106 @@ CREATE SEQUENCE public.users_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.users_id_seq OWNER TO cloud;
-
 --
--- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: cloud
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
--- Name: projects id; Type: DEFAULT; Schema: public; Owner: cloud
+-- Name: collection_memberships id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collection_memberships ALTER COLUMN id SET DEFAULT nextval('public.collection_memberships_id_seq'::regclass);
+
+
+--
+-- Name: collections id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collections ALTER COLUMN id SET DEFAULT nextval('public.collections_id_seq'::regclass);
+
+
+--
+-- Name: flagged_projects id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.flagged_projects ALTER COLUMN id SET DEFAULT nextval('public.flagged_projects_id_seq'::regclass);
+
+
+--
+-- Name: projects id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects ALTER COLUMN id SET DEFAULT nextval('public.projects_id_seq'::regclass);
 
 
 --
--- Name: users id; Type: DEFAULT; Schema: public; Owner: cloud
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
--- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: cloud
+-- Name: banned_ips banned_ips_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.banned_ips
+    ADD CONSTRAINT banned_ips_pkey PRIMARY KEY (ip);
+
+
+--
+-- Name: collection_memberships collection_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collection_memberships
+    ADD CONSTRAINT collection_memberships_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: collections collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collections
+    ADD CONSTRAINT collections_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: featured_collections featured_collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.featured_collections
+    ADD CONSTRAINT featured_collections_pkey PRIMARY KEY (collection_id, page_path);
+
+
+--
+-- Name: flagged_projects flagged_projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.flagged_projects
+    ADD CONSTRAINT flagged_projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: followers followers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.followers
+    ADD CONSTRAINT followers_pkey PRIMARY KEY (follower_id, followed_id);
+
+
+--
+-- Name: lapis_migrations lapis_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.lapis_migrations
+    ADD CONSTRAINT lapis_migrations_pkey PRIMARY KEY (name);
+
+
+--
+-- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects
@@ -319,7 +550,7 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: projects unique_id; Type: CONSTRAINT; Schema: public; Owner: cloud
+-- Name: projects unique_id; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects
@@ -327,7 +558,7 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: cloud
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users
@@ -335,7 +566,15 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: tokens value_pkey; Type: CONSTRAINT; Schema: public; Owner: cloud
+-- Name: users users_unique_email_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_unique_email_key UNIQUE (unique_email);
+
+
+--
+-- Name: tokens value_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tokens
@@ -343,36 +582,78 @@ ALTER TABLE ONLY public.tokens
 
 
 --
--- Name: original_project_id_index; Type: INDEX; Schema: public; Owner: cloud
+-- Name: collection_memberships_collection_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX collection_memberships_collection_id_idx ON public.collection_memberships USING btree (collection_id);
+
+
+--
+-- Name: collection_memberships_collection_id_project_id_user_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX collection_memberships_collection_id_project_id_user_id_idx ON public.collection_memberships USING btree (collection_id, project_id, user_id);
+
+
+--
+-- Name: collection_memberships_project_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX collection_memberships_project_id_idx ON public.collection_memberships USING btree (project_id);
+
+
+--
+-- Name: collections_creator_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX collections_creator_id_idx ON public.collections USING btree (creator_id);
+
+
+--
+-- Name: flagged_projects_flagger_id_project_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX flagged_projects_flagger_id_project_id_idx ON public.flagged_projects USING btree (flagger_id, project_id);
+
+
+--
+-- Name: original_project_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX original_project_id_index ON public.remixes USING btree (original_project_id);
 
 
 --
--- Name: remixed_project_id_index; Type: INDEX; Schema: public; Owner: cloud
+-- Name: remixed_project_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX remixed_project_id_index ON public.remixes USING btree (remixed_project_id);
 
 
 --
--- Name: tokens expire_token_trigger; Type: TRIGGER; Schema: public; Owner: cloud
+-- Name: users_email_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE TRIGGER expire_token_trigger AFTER INSERT ON public.tokens FOR EACH STATEMENT EXECUTE PROCEDURE public.expire_token();
+CREATE INDEX users_email_idx ON public.users USING btree (email);
 
 
 --
--- Name: projects projects_username_fkey; Type: FK CONSTRAINT; Schema: public; Owner: cloud
+-- Name: tokens expire_token_trigger; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER expire_token_trigger AFTER INSERT ON public.tokens FOR EACH STATEMENT EXECUTE FUNCTION public.expire_token();
+
+
+--
+-- Name: projects projects_username_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects
-    ADD CONSTRAINT projects_username_fkey FOREIGN KEY (username) REFERENCES public.users(username);
+    ADD CONSTRAINT projects_username_fkey FOREIGN KEY (username) REFERENCES public.users(username) ON UPDATE CASCADE;
 
 
 --
--- Name: remixes remixes_original_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: cloud
+-- Name: remixes remixes_original_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.remixes
@@ -380,7 +661,7 @@ ALTER TABLE ONLY public.remixes
 
 
 --
--- Name: remixes remixes_remixed_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: cloud
+-- Name: remixes remixes_remixed_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.remixes
@@ -388,102 +669,178 @@ ALTER TABLE ONLY public.remixes
 
 
 --
--- Name: tokens users_fkey; Type: FK CONSTRAINT; Schema: public; Owner: cloud
+-- Name: tokens users_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tokens
-    ADD CONSTRAINT users_fkey FOREIGN KEY (username) REFERENCES public.users(username);
+    ADD CONSTRAINT users_fkey FOREIGN KEY (username) REFERENCES public.users(username) ON UPDATE CASCADE;
 
 
 --
--- Name: FUNCTION expire_token(); Type: ACL; Schema: public; Owner: cloud
+-- Name: DATABASE snapcloud; Type: ACL; Schema: -; Owner: -
+--
+
+GRANT CONNECT,TEMPORARY ON DATABASE snapcloud TO snapanalytics;
+
+
+--
+-- Name: FUNCTION expire_token(); Type: ACL; Schema: public; Owner: -
 --
 
 GRANT ALL ON FUNCTION public.expire_token() TO snapanalytics;
 
 
 --
--- Name: TABLE projects; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE pg_stat_bgwriter; Type: ACL; Schema: pg_catalog; Owner: -
+--
+
+GRANT SELECT ON TABLE pg_catalog.pg_stat_bgwriter TO newrelic;
+
+
+--
+-- Name: TABLE pg_stat_database; Type: ACL; Schema: pg_catalog; Owner: -
+--
+
+GRANT SELECT ON TABLE pg_catalog.pg_stat_database TO newrelic;
+
+
+--
+-- Name: TABLE pg_stat_database_conflicts; Type: ACL; Schema: pg_catalog; Owner: -
+--
+
+GRANT SELECT ON TABLE pg_catalog.pg_stat_database_conflicts TO newrelic;
+
+
+--
+-- Name: TABLE projects; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.projects TO snapanalytics;
 
 
 --
--- Name: TABLE active_projects; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE active_projects; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.active_projects TO snapanalytics;
 
 
 --
--- Name: TABLE users; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE users; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.users TO snapanalytics;
 
 
 --
--- Name: COLUMN users.email; Type: ACL; Schema: public; Owner: cloud
+-- Name: COLUMN users.email; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT UPDATE(email) ON TABLE public.users TO snapanalytics;
 
 
 --
--- Name: TABLE active_users; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE active_users; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.active_users TO snapanalytics;
 
 
 --
--- Name: TABLE count_recent_projects; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE banned_ips; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT SELECT ON TABLE public.banned_ips TO snapanalytics;
+
+
+--
+-- Name: TABLE collection_memberships; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT SELECT ON TABLE public.collection_memberships TO snapanalytics;
+
+
+--
+-- Name: TABLE collections; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT SELECT ON TABLE public.collections TO snapanalytics;
+
+
+--
+-- Name: TABLE count_recent_projects; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.count_recent_projects TO snapanalytics;
 
 
 --
--- Name: TABLE deleted_projects; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE deleted_projects; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.deleted_projects TO snapanalytics;
 
 
 --
--- Name: TABLE deleted_users; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE deleted_users; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.deleted_users TO snapanalytics;
 
 
 --
--- Name: TABLE recent_projects_2_days; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE featured_collections; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT SELECT ON TABLE public.featured_collections TO snapanalytics;
+
+
+--
+-- Name: TABLE flagged_projects; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT SELECT ON TABLE public.flagged_projects TO snapanalytics;
+
+
+--
+-- Name: TABLE followers; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT SELECT ON TABLE public.followers TO snapanalytics;
+
+
+--
+-- Name: TABLE lapis_migrations; Type: ACL; Schema: public; Owner: -
+--
+
+GRANT SELECT ON TABLE public.lapis_migrations TO snapanalytics;
+
+
+--
+-- Name: TABLE recent_projects_2_days; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.recent_projects_2_days TO snapanalytics;
 
 
 --
--- Name: TABLE remixes; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE remixes; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.remixes TO snapanalytics;
 
 
 --
--- Name: TABLE tokens; Type: ACL; Schema: public; Owner: cloud
+-- Name: TABLE tokens; Type: ACL; Schema: public; Owner: -
 --
 
 GRANT SELECT ON TABLE public.tokens TO snapanalytics;
 
 
 --
--- Name: DEFAULT PRIVILEGES FOR TABLES; Type: DEFAULT ACL; Schema: public; Owner: cloud
+-- Name: DEFAULT PRIVILEGES FOR TABLES; Type: DEFAULT ACL; Schema: public; Owner: -
 --
 
-ALTER DEFAULT PRIVILEGES FOR ROLE cloud IN SCHEMA public REVOKE ALL ON TABLES  FROM cloud;
 ALTER DEFAULT PRIVILEGES FOR ROLE cloud IN SCHEMA public GRANT SELECT ON TABLES  TO snapanalytics;
 
 

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,7 @@ local config = require('lapis.config')
 
 config({'development', 'staging', 'production', 'test'}, {
     postgres = {
-        host = os.getenv('DATABASE_URL') or '127.0.0.1',
+        host = os.getenv('DATABASE_HOST) or '127.0.0.1',
         port = os.getenv('DATABASE_PORT') or '5432',
         user = os.getenv('DATABASE_USERNAME') or 'cloud',
         password = os.getenv('DATABASE_PASSWORD') or 'snap-cloud-password',

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,8 @@ local config = require('lapis.config')
 
 config({'development', 'staging', 'production', 'test'}, {
     postgres = {
-        host = os.getenv('DATABASE_URL') or '127.0.0.1:5432',
+        host = os.getenv('DATABASE_URL') or '127.0.0.1',
+        port = os.getenv('DATABASE_PORT') or '5432',
         user = os.getenv('DATABASE_USERNAME') or 'cloud',
         password = os.getenv('DATABASE_PASSWORD') or 'snap-cloud-password',
         database = os.getenv('DATABASE_NAME') or 'snapcloud'


### PR DESCRIPTION
**Separate PORT from DATABASE_URL. This allows lapis migrate to work correctly.
* no longer need the custom/hackey migrations script. bin/lapis-migrate now also dumps
the schema if running in development
* we no longer need the dump_schema file
* regen cloud.sql with the current setup
