### PR TITLE
Enable gzip in nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,7 @@ http {
         require "socket"
     }
 
+    include nginx.conf.d/compression.conf;
     include nginx.conf.d/logging.conf;
     include nginx.conf.d/mime.types;
 

--- a/nginx.conf.d/compression.conf
+++ b/nginx.conf.d/compression.conf
@@ -1,0 +1,39 @@
+##
+# Gzip Settings
+##
+
+gzip on;
+gzip_disable "MSIE [1-6]\.";
+
+# Only allow proxy request with these headers to be gzipped.
+gzip_proxied expired no-cache no-store private auth;
+
+# Default is 6 (1<n<9), but 2 -- even 1 -- is enough. The higher it is, the
+# more CPU cycles will be wasted.
+gzip_comp_level 6;
+
+gzip_vary on;
+gzip_proxied any;
+gzip_buffers 16 8k;
+gzip_http_version 1.1;
+gzip_min_length 512;
+gzip_types
+  application/atom+xml
+  application/geo+json
+  application/javascript
+  application/x-javascript
+  application/json
+  application/ld+json
+  application/manifest+json
+  application/rdf+xml
+  application/rss+xml
+  application/xhtml+xml
+  application/xml
+  font/eot
+  font/otf
+  font/ttf
+  image/svg+xml
+  text/css
+  text/javascript
+  text/plain
+  text/xml;


### PR DESCRIPTION
took a swing at #51, untested

Two knobs to consider adjusting:
* `gzip_min_length` - recommendations can range from (256, 500, 1024) bytes.
* `gzip_comp_level` - set at 6, but not sure this is even worth setting explicitly ([default is is `1`](http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_comp_level))

Sources:
* https://gist.github.com/v0lkan/90fcb83c86918732b894
* https://www.digitalocean.com/community/tutorials/how-to-improve-website-performance-using-gzip-and-nginx-on-ubuntu-20-04
* https://ubiq.co/tech-blog/how-to-enable-nginx-gzip-compression/