### PR TITLE
Annotate + Separate models in individual files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: annotate install-annotate install-deps migrate
+
+default:
+	@echo "Please specify a target."
+
+annotate:
+	lapis annotate --preload-module "models" models/*.lua
+
+install-annotate:
+	luarocks install --lua-version=5.1 https://raw.githubusercontent.com/snap-cloud/lapis-annotate/support-native-lua/lapis-annotate-dev-1.rockspec
+
+install-deps:
+	bin/luarocks-macos install --only-deps snapcloud-dev-0.rockspec
+	install-annotate
+
+migrate:
+	bin/lapis-migrate

--- a/app.lua
+++ b/app.lua
@@ -30,7 +30,6 @@ local lapis = require('lapis')
 package.loaded.app = lapis.Application()
 package.loaded.db = require('lapis.db')
 package.loaded.validate = require('lapis.validate')
-package.loaded.Model = require('lapis.db.model').Model
 package.loaded.util = require('lapis.util')
 package.loaded.resty_sha512 = require('resty.sha512')
 package.loaded.resty_string = require('resty.string')

--- a/app.lua
+++ b/app.lua
@@ -1,4 +1,4 @@
--- Snap Cloud
+-- Snap!Cloud
 -- ==========
 --
 -- A cloud backend for Snap!

--- a/models.lua
+++ b/models.lua
@@ -21,5 +21,15 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+package.loaded.BannedIPs = require("models.banned_ips")
+package.loaded.CollectionMemberships = require("models.collection_memberships")
+package.loaded.Collections = require("models.collections" )
+package.loaded.FeaturedCollections = require("models.featured_collections")
+package.loaded.FlaggedProjects = require("models.flagged_projects")
+package.loaded.Followers = require("models.followers" )
+package.loaded.Projects = require("models.projects")
+package.loaded.Remixes = require("models.remixes" )
+package.loaded.Tokens = require("models.tokes" )
+package.loaded.Users = require("models.users" )
+
+-- return require("lapis.util").autoload("models")

--- a/models.lua
+++ b/models.lua
@@ -21,6 +21,12 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
+package.loaded.Model = require('lapis.db.model').Model
+
+-- TODO: This does not acutlly autoload the models
+-- In the meantime, we will require them manually
+-- return require("lapis.util").autoload("models")
+
 package.loaded.BannedIPs = require("models.banned_ips")
 package.loaded.CollectionMemberships = require("models.collection_memberships")
 package.loaded.Collections = require("models.collections" )
@@ -31,5 +37,3 @@ package.loaded.Projects = require("models.projects")
 package.loaded.Remixes = require("models.remixes" )
 package.loaded.Tokens = require("models.tokes" )
 package.loaded.Users = require("models.users" )
-
--- return require("lapis.util").autoload("models")

--- a/models/banned_ips.lua
+++ b/models/banned_ips.lua
@@ -23,12 +23,20 @@
 
 local Model = package.loaded.Model
 
-local banned_ips = Model:extend(
-    'banned_ips', {
-        primary_key = 'ip',
-        timestamp = true
-    }
-)
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE banned_ips (
+--   ip text NOT NULL,
+--   created_at timestamp with time zone NOT NULL,
+--   updated_at timestamp with time zone NOT NULL,
+--   offense_count integer DEFAULT 0 NOT NULL
+-- );
+-- ALTER TABLE ONLY banned_ips
+--   ADD CONSTRAINT banned_ips_pkey PRIMARY KEY (ip);
+--
+local BannedIPs = Model:extend ('banned_ips', {
+    primary_key = 'ip',
+    timestamp = true
+})
 
-package.loaded.BannedIPs = banned_ips
-return banned_ips
+return BannedIPs

--- a/models/banned_ips.lua
+++ b/models/banned_ips.lua
@@ -1,5 +1,5 @@
--- Database abstractions
--- =====================
+-- Snap!Cloud Banned IPs Model
+-- ===========================
 --
 -- A cloud backend for Snap!
 -- Written by Bernat Romagosa and Michael Ball
@@ -21,5 +21,14 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+local Model = package.loaded.Model
+
+local banned_ips = Model:extend(
+    'banned_ips', {
+        primary_key = 'ip',
+        timestamp = true
+    }
+)
+
+package.loaded.BannedIPs = banned_ips
+return banned_ips

--- a/models/collection_memberships.lua
+++ b/models/collection_memberships.lua
@@ -23,10 +23,25 @@
 
 local Model = package.loaded.Model
 
-local collection_memberships = Model:extend('collection_memberships', {
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE collection_memberships (
+--   id integer NOT NULL,
+--   collection_id integer NOT NULL,
+--   project_id integer NOT NULL,
+--   created_at timestamp with time zone NOT NULL,
+--   updated_at timestamp with time zone NOT NULL,
+--   user_id integer NOT NULL
+-- );
+-- ALTER TABLE ONLY collection_memberships
+--   ADD CONSTRAINT collection_memberships_pkey PRIMARY KEY (id);
+-- CREATE INDEX collection_memberships_collection_id_idx ON collection_memberships USING btree (collection_id);
+-- CREATE UNIQUE INDEX collection_memberships_collection_id_project_id_user_id_idx ON collection_memberships USING btree (collection_id, project_id, user_id);
+-- CREATE INDEX collection_memberships_project_id_idx ON collection_memberships USING btree (project_id);
+--
+local CollectionMemberships =  Model:extend('collection_memberships', {
     primary_key = {'collection_id', 'project_id'},
     timestamp = true
 })
 
-package.loaded.CollectionMemberships = collection_memberships
-return collection_memberships
+return CollectionMemberships

--- a/models/collection_memberships.lua
+++ b/models/collection_memberships.lua
@@ -1,5 +1,5 @@
--- Database abstractions
--- =====================
+-- Snap!Cloud Collection Memberships Model
+-- =======================================
 --
 -- A cloud backend for Snap!
 -- Written by Bernat Romagosa and Michael Ball
@@ -21,5 +21,12 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+local Model = package.loaded.Model
+
+local collection_memberships = Model:extend('collection_memberships', {
+    primary_key = {'collection_id', 'project_id'},
+    timestamp = true
+})
+
+package.loaded.CollectionMemberships = collection_memberships
+return collection_memberships

--- a/models/collections.lua
+++ b/models/collections.lua
@@ -23,9 +23,30 @@
 
 local db = package.loaded.db
 local Model = package.loaded.Model
-local escape = package.loaded.util.escape
+local escape = require('lapis.util').escape
 
-local collections = Model:extend('collections', {
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE collections (
+--   id integer NOT NULL,
+--   name text NOT NULL,
+--   creator_id integer NOT NULL,
+--   created_at timestamp with time zone NOT NULL,
+--   updated_at timestamp with time zone NOT NULL,
+--   description text,
+--   published boolean DEFAULT false NOT NULL,
+--   published_at timestamp with time zone,
+--   shared boolean DEFAULT false NOT NULL,
+--   shared_at timestamp with time zone,
+--   thumbnail_id integer,
+--   editor_ids integer[],
+--   free_for_all boolean DEFAULT false NOT NULL
+-- );
+-- ALTER TABLE ONLY collections
+--   ADD CONSTRAINT collections_pkey PRIMARY KEY (id);
+-- CREATE INDEX collections_creator_id_idx ON collections USING btree (creator_id);
+--
+local Collections =  Model:extend('collections', {
     type = 'collection',
     primary_key = {'creator_id', 'name'},
     timestamp = true,
@@ -105,5 +126,4 @@ local collections = Model:extend('collections', {
     end
 })
 
-package.loaded.Collections = collections
-return collections
+return Collections

--- a/models/collections.lua
+++ b/models/collections.lua
@@ -1,0 +1,109 @@
+-- Snap!Cloud Collections Model
+-- ============================
+--
+-- A cloud backend for Snap!
+-- Written by Bernat Romagosa and Michael Ball
+--
+-- Copyright (C) 2024 by Bernat Romagosa and Michael Ball
+--
+-- This file is part of Snap Cloud.
+--
+-- Snap Cloud is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of
+-- the License, or (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
+
+local db = package.loaded.db
+local Model = package.loaded.Model
+local escape = package.loaded.util.escape
+
+local collections = Model:extend('collections', {
+    type = 'collection',
+    primary_key = {'creator_id', 'name'},
+    timestamp = true,
+    url_for = function (self, purpose)
+        if not self.username then
+            if not self.creator then
+                self.creator = package.loaded.Users:find(self.creator_id)
+            end
+            self.username = self.creator.username
+        end
+        local urls = {
+            site = '/collection?username=' .. escape(self.username) ..
+                '&collection=' .. escape(self.name),
+            author = '/user?username=' .. escape(self.username)
+        }
+        return urls[purpose]
+    end,
+    relations = {
+        -- creates Collection:get_creator()
+        {'creator', belongs_to = 'Users', key = 'creator_id'},
+        {'memberships', has_many = 'CollectionMemberships'},
+        {'projects',
+            fetch = function (self)
+                local query = db.interpolate_query(
+                    [[ INNER JOIN (
+                            SELECT project_id, created_at
+                            FROM collection_memberships
+                            WHERE collection_id = ?)
+                        AS memberships
+                        ON active_projects.id = memberships.project_id
+                        ORDER BY memberships.created_at DESC ]],
+                    self.id)
+                return package.loaded.Projects:paginated(query)
+            end
+        },
+        {'shared_and_published_projects',
+            fetch = function (self)
+                local query = db.interpolate_query(
+                    [[ INNER JOIN (
+                            SELECT project_id, created_at
+                            FROM collection_memberships
+                            WHERE collection_id = ?)
+                        AS memberships
+                        ON active_projects.id = memberships.project_id
+                        WHERE (ispublished OR ispublic)
+                        ORDER BY memberships.created_at DESC ]],
+                    self.id)
+                return package.loaded.Projects:paginated(query)
+            end
+        },
+        {'published_projects',
+            fetch = function (self)
+                local query = db.interpolate_query(
+                    [[ INNER JOIN (
+                            SELECT project_id, created_at
+                            FROM collection_memberships
+                            WHERE collection_id = ?)
+                        AS memberships
+                        ON active_projects.id = memberships.project_id
+                        WHERE ispublished
+                        ORDER BY memberships.created_at DESC ]],
+                    self.id)
+                return package.loaded.Projects:paginated(query)
+            end
+        }
+    },
+    constraints = {
+        name = function(self, value)
+            if not value then
+                return 'A name must be present'
+            end
+        end
+    },
+    count_projects = function (self)
+        return package.loaded.CollectionMemberships:count('collection_id = ?',
+                                                          self.id)
+    end
+})
+
+package.loaded.Collections = collections
+return collections

--- a/models/featured_collections.lua
+++ b/models/featured_collections.lua
@@ -1,5 +1,5 @@
--- Database abstractions
--- =====================
+-- Snap!Cloud Featured Collections Model
+-- =====================================
 --
 -- A cloud backend for Snap!
 -- Written by Bernat Romagosa and Michael Ball
@@ -21,5 +21,14 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+local Model = package.loaded.Model
+
+local featured_collections = Model:extend(
+    'featured_collections', {
+        primary_key = {'collection_id', 'page_path'},
+        timestamp = true
+    }
+)
+
+package.loaded.FeaturedCollections = featured_collections
+return featured_collections

--- a/models/featured_collections.lua
+++ b/models/featured_collections.lua
@@ -23,12 +23,22 @@
 
 local Model = package.loaded.Model
 
-local featured_collections = Model:extend(
-    'featured_collections', {
-        primary_key = {'collection_id', 'page_path'},
-        timestamp = true
-    }
-)
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE featured_collections (
+--   collection_id integer NOT NULL,
+--   page_path text NOT NULL,
+--   type text NOT NULL,
+--   "order" integer DEFAULT 0 NOT NULL,
+--   created_at timestamp with time zone NOT NULL,
+--   updated_at timestamp with time zone NOT NULL
+-- );
+-- ALTER TABLE ONLY featured_collections
+--   ADD CONSTRAINT featured_collections_pkey PRIMARY KEY (collection_id, page_path);
+--
+local FeaturedCollections =  Model:extend('featured_collections', {
+    primary_key = {'collection_id', 'page_path'},
+    timestamp = true
+})
 
-package.loaded.FeaturedCollections = featured_collections
-return featured_collections
+return FeaturedCollections

--- a/models/flagged_projects.lua
+++ b/models/flagged_projects.lua
@@ -23,12 +23,24 @@
 
 local Model = package.loaded.Model
 
-local flagged_projects = Model:extend(
-    'flagged_projects', {
-        primary_key = 'id',
-        timestamp = true
-    }
-)
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE flagged_projects (
+--   id integer NOT NULL,
+--   flagger_id integer NOT NULL,
+--   project_id integer NOT NULL,
+--   reason text NOT NULL,
+--   created_at timestamp with time zone NOT NULL,
+--   updated_at timestamp with time zone NOT NULL,
+--   notes text
+-- );
+-- ALTER TABLE ONLY flagged_projects
+--   ADD CONSTRAINT flagged_projects_pkey PRIMARY KEY (id);
+-- CREATE UNIQUE INDEX flagged_projects_flagger_id_project_id_idx ON flagged_projects USING btree (flagger_id, project_id);
+--
+local FlaggedProjects =  Model:extend('flagged_projects', {
+    primary_key = 'id',
+    timestamp = true
+})
 
-package.loaded.FlaggedProjects = flagged_projects
-return flagged_projects
+return FlaggedProjects

--- a/models/flagged_projects.lua
+++ b/models/flagged_projects.lua
@@ -1,5 +1,5 @@
--- Database abstractions
--- =====================
+-- Snap!Cloud Flagged Projects Model
+-- =================================
 --
 -- A cloud backend for Snap!
 -- Written by Bernat Romagosa and Michael Ball
@@ -21,5 +21,14 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+local Model = package.loaded.Model
+
+local flagged_projects = Model:extend(
+    'flagged_projects', {
+        primary_key = 'id',
+        timestamp = true
+    }
+)
+
+package.loaded.FlaggedProjects = flagged_projects
+return flagged_projects

--- a/models/followers.lua
+++ b/models/followers.lua
@@ -23,12 +23,20 @@
 
 local Model = package.loaded.Model
 
-local followers = Model:extend(
-    'followers', {
-        primary_key = {'follower_id', 'followed_id'},
-        timestamp = true
-    }
-)
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE followers (
+--   follower_id integer NOT NULL,
+--   followed_id integer NOT NULL,
+--   created_at timestamp with time zone NOT NULL,
+--   updated_at timestamp with time zone NOT NULL
+-- );
+-- ALTER TABLE ONLY followers
+--   ADD CONSTRAINT followers_pkey PRIMARY KEY (follower_id, followed_id);
+--
+local Followers =  Model:extend('followers', {
+    primary_key = {'follower_id', 'followed_id'},
+    timestamp = true
+})
 
-package.loaded.Followers = followers
-return followers
+return Followers

--- a/models/followers.lua
+++ b/models/followers.lua
@@ -1,5 +1,5 @@
--- Database abstractions
--- =====================
+-- Snap!Cloud Followers Model
+-- ==========================
 --
 -- A cloud backend for Snap!
 -- Written by Bernat Romagosa and Michael Ball
@@ -21,5 +21,14 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+local Model = package.loaded.Model
+
+local followers = Model:extend(
+    'followers', {
+        primary_key = {'follower_id', 'followed_id'},
+        timestamp = true
+    }
+)
+
+package.loaded.Followers = followers
+return followers

--- a/models/projects.lua
+++ b/models/projects.lua
@@ -124,5 +124,4 @@ package.loaded.DeletedProjects = Model:extend('deleted_projects', {
     primary_key = {'username', 'projectname'}
 })
 
-package.loaded.Projects = ActiveProjects
 return ActiveProjects

--- a/models/projects.lua
+++ b/models/projects.lua
@@ -1,0 +1,111 @@
+-- Snap!Cloud Projects Model
+-- =========================
+--
+-- A cloud backend for Snap!
+-- Written by Bernat Romagosa and Michael Ball
+--
+-- Copyright (C) 2024 by Bernat Romagosa and Michael Ball
+--
+-- This file is part of Snap Cloud.
+--
+-- Snap Cloud is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of
+-- the License, or (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
+
+local db = package.loaded.db
+local Model = package.loaded.Model
+
+local escape = package.loaded.util.escape
+local disk = package.loaded.disk
+
+local active_projects = Model:extend('active_projects', {
+    type = 'project',
+    primary_key = {'username', 'projectname'},
+    constraints = {
+        projectname = function (_self, name)
+            if not name or string.len(name) < 1 then
+                return "Project names must have at least one character."
+            end
+        end
+    },
+    url_for = function (self, purpose, dev_version)
+        local base = 'https://snap.berkeley.edu/' ..
+            (dev_version and 'snapsource/dev/' or '') ..
+            'snap.html'
+        local urls = {
+            viewer = base ..
+                '#present:Username=' .. escape(self.username) ..
+                '&ProjectName=' .. escape(self.projectname) ..
+                '&embedMode&noExitWarning&noRun',
+            open = base ..
+                '#present:Username=' .. escape(self.username) ..
+                '&ProjectName=' .. escape(self.projectname) ..
+                '&editMode&noRun',
+            download = '/project/' .. escape(self.id),
+            site = '/project?username=' .. escape(self.username) ..
+                '&projectname=' .. escape(self.projectname),
+            author = '/user?username=' .. escape(self.username),
+            embed = 'https://snap.berkeley.edu/embed?projectname=' ..
+                escape(self.projectname) .. '&username=' ..
+                escape(self.username)
+        }
+        return urls[purpose]
+    end,
+    relations = {
+        {'flags',
+            fetch = function (self)
+                return package.loaded.FlaggedProjects:select(
+                    'JOIN active_users ON active_users.id = flagger_id '..
+                    'WHERE project_id = ? ' ..
+                    'GROUP BY reason, username, created_at, notes',
+                    self.id,
+                    { fields = 'username, created_at, reason, notes' }
+                )
+            end
+        },
+        {'public_remixes',
+            fetch = function (self)
+                local items = package.loaded.Projects:select(
+                   [[JOIN remixes
+                        ON active_projects.id = remixes.remixed_project_id
+                    WHERE remixes.original_project_id = ?
+                    AND ispublic]],
+                    self.id
+                )
+                disk:process_thumbnails(items)
+                return items
+            end
+        },
+        {'public_collections',
+            fetch = function (self)
+                local items = package.loaded.Collections:select(
+                    [[INNER JOIN collection_memberships
+                        ON collection_memberships.collection_id = collections.id
+                    INNER JOIN users
+                        ON collections.creator_id = users.id
+                    WHERE collection_memberships.project_id = ?
+                    AND collections.published]],
+                    self.id
+                )
+                disk:process_thumbnails(items, 'thumbnail_id')
+                return items
+            end
+        }
+    }
+})
+
+package.loaded.DeletedProjects = Model:extend('deleted_projects', {
+    primary_key = {'username', 'projectname'}
+})
+
+package.loaded.Projects = active_projects
+return active_projects

--- a/models/projects.lua
+++ b/models/projects.lua
@@ -24,10 +24,27 @@
 local db = package.loaded.db
 local Model = package.loaded.Model
 
-local escape = package.loaded.util.escape
+local escape = require('lapis.util').escape
 local disk = package.loaded.disk
 
-local active_projects = Model:extend('active_projects', {
+-- Generated schema dump: (do not edit)
+--
+-- CREATE VIEW active_projects AS
+--  SELECT projects.id,
+--   projects.projectname,
+--   projects.ispublic,
+--   projects.ispublished,
+--   projects.notes,
+--   projects.created,
+--   projects.lastupdated,
+--   projects.lastshared,
+--   projects.username,
+--   projects.firstpublished,
+--   projects.deleted
+--    FROM public.projects
+--   WHERE (projects.deleted IS NULL);
+--
+local ActiveProjects =  Model:extend('active_projects', {
     type = 'project',
     primary_key = {'username', 'projectname'},
     constraints = {
@@ -107,5 +124,5 @@ package.loaded.DeletedProjects = Model:extend('deleted_projects', {
     primary_key = {'username', 'projectname'}
 })
 
-package.loaded.Projects = active_projects
-return active_projects
+package.loaded.Projects = ActiveProjects
+return ActiveProjects

--- a/models/remixes.lua
+++ b/models/remixes.lua
@@ -1,5 +1,5 @@
--- Database abstractions
--- =====================
+-- Snap!Cloud Remixes Model
+-- ========================
 --
 -- A cloud backend for Snap!
 -- Written by Bernat Romagosa and Michael Ball
@@ -21,5 +21,11 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+local Model = package.loaded.Model
+
+local remixes = Model:extend('remixes', {
+    primary_key = {'original_project_id', 'remixed_project_id'}
+})
+
+package.loaded.Remixes = remixes
+return remixes

--- a/models/remixes.lua
+++ b/models/remixes.lua
@@ -23,9 +23,22 @@
 
 local Model = package.loaded.Model
 
-local remixes = Model:extend('remixes', {
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE remixes (
+--   original_project_id integer,
+--   remixed_project_id integer NOT NULL,
+--   created timestamp with time zone
+-- );
+-- CREATE INDEX original_project_id_index ON remixes USING btree (original_project_id);
+-- CREATE INDEX remixed_project_id_index ON remixes USING btree (remixed_project_id);
+-- ALTER TABLE ONLY remixes
+--   ADD CONSTRAINT remixes_original_project_id_fkey FOREIGN KEY (original_project_id) REFERENCES public.projects(id);
+-- ALTER TABLE ONLY remixes
+--   ADD CONSTRAINT remixes_remixed_project_id_fkey FOREIGN KEY (remixed_project_id) REFERENCES public.projects(id);
+--
+local Remixes =  Model:extend('remixes', {
     primary_key = {'original_project_id', 'remixed_project_id'}
 })
 
-package.loaded.Remixes = remixes
-return remixes
+return Remixes

--- a/models/tokes.lua
+++ b/models/tokes.lua
@@ -23,9 +23,22 @@
 
 local Model = package.loaded.Model
 
-local tokens = Model:extend('tokens', {
+-- Generated schema dump: (do not edit)
+--
+-- CREATE TABLE tokens (
+--   created timestamp without time zone DEFAULT now() NOT NULL,
+--   username public.dom_username NOT NULL,
+--   purpose text,
+--   value text NOT NULL
+-- );
+-- ALTER TABLE ONLY tokens
+--   ADD CONSTRAINT value_pkey PRIMARY KEY (value);
+-- CREATE TRIGGER expire_token_trigger AFTER INSERT ON tokens FOR EACH STATEMENT EXECUTE FUNCTION public.expire_token();
+-- ALTER TABLE ONLY tokens
+--   ADD CONSTRAINT users_fkey FOREIGN KEY (username) REFERENCES public.users(username) ON UPDATE CASCADE;
+--
+local Tokens =  Model:extend('tokens', {
     primary_key = {'value'}
 })
 
-package.loaded.Tokens = tokens
-return tokens
+return Tokens

--- a/models/tokes.lua
+++ b/models/tokes.lua
@@ -1,5 +1,5 @@
--- Database abstractions
--- =====================
+-- Snap!Cloud Tokens Model
+-- =======================
 --
 -- A cloud backend for Snap!
 -- Written by Bernat Romagosa and Michael Ball
@@ -21,5 +21,11 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
-local autoload = require("lapis.util").autoload
-autoload("models")
+local Model = package.loaded.Model
+
+local tokens = Model:extend('tokens', {
+    primary_key = {'value'}
+})
+
+package.loaded.Tokens = tokens
+return tokens

--- a/models/users.lua
+++ b/models/users.lua
@@ -22,9 +22,30 @@
 -- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
 
 local Model = package.loaded.Model
-local escape = package.loaded.util.escape
+local escape = require('lapis.util').escape
 
-local active_users = Model:extend('active_users', {
+-- Generated schema dump: (do not edit)
+--
+-- CREATE VIEW active_users AS
+--  SELECT users.id,
+--   users.created,
+--   users.username,
+--   users.email,
+--   users.salt,
+--   users.password,
+--   users.about,
+--   users.location,
+--   users.verified,
+--   users.role,
+--   users.deleted,
+--   users.unique_email,
+--   users.bad_flags,
+--   users.is_teacher,
+--   users.creator_id
+--    FROM public.users
+--   WHERE (users.deleted IS NULL);
+--
+local ActiveUsers =  Model:extend('active_users', {
     type = 'user',
     relations = {
         {'collections', has_many = 'Collections'},
@@ -136,16 +157,15 @@ local active_users = Model:extend('active_users', {
     end
 })
 
-package.loaded.Users = active_users
 
 -- Note: Due to client-side pre-hashing, password length isn't useful...
-package.loaded.Users.validations = {
+ActiveUsers.validations = {
     { 'username', exists = true, min_length = 4, max_length = 200 },
     { 'password', exists = true, min_length = 6 },
     { 'email', exists = true, min_length = 5 }
 }
 
-package.loaded.Users.roles = {
+ActiveUsers.roles = {
     admin = 5,
     moderator = 4,
     reviewer = 3,
@@ -159,4 +179,4 @@ package.loaded.DeletedUsers = Model:extend('deleted_users')
 -- Used for querires across the entire users table.
 package.loaded.AllUsers = Model:extend('users')
 
-return active_users
+return ActiveUsers

--- a/models/users.lua
+++ b/models/users.lua
@@ -1,0 +1,162 @@
+-- Snap!Cloud User Model
+-- =====================
+--
+-- A cloud backend for Snap!
+-- Written by Bernat Romagosa and Michael Ball
+--
+-- Copyright (C) 2024 by Bernat Romagosa and Michael Ball
+--
+-- This file is part of Snap Cloud.
+--
+-- Snap Cloud is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of
+-- the License, or (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <http://www.gnu.org/licenses/>.-
+
+local Model = package.loaded.Model
+local escape = package.loaded.util.escape
+
+local active_users = Model:extend('active_users', {
+    type = 'user',
+    relations = {
+        {'collections', has_many = 'Collections'},
+        {'editable_collections',
+            fetch = function (self)
+                return package.loaded.Collections:select(
+                    [[WHERE (collections.creator_id = ? OR editor_ids @> array[?]) OR
+                        collections.free_for_all]],
+                    self.id,
+                    self.id,
+                    { fields = 'name, collections.id' }
+                )
+            end
+        },
+        {'ffa_collections',
+            fetch = function (self)
+                return package.loaded.Collections:select(
+                    [[WHERE collections.creator_id = ? AND collections.free_for_all]],
+                    self.id,
+                    { fields = 'name, collections.id' }
+                )
+            end
+        },
+        {'public_collections',
+            fetch = function (self)
+                return package.loaded.Collections:select(
+                    [[WHERE collections.creator_id = ? AND published ]],
+                    self.id,
+                    { fields = 'name, collections.id' }
+                )
+            end
+        },
+        {'project_count',
+            fetch = function (self)
+                return package.loaded.Projects:select(
+                    'WHERE username = ?',
+                    self.username,
+                    { fields = 'count(*) as count' }
+                )[1].count
+            end
+        },
+    },
+    follows = function (self, a_user)
+        return package.loaded.Followers:find({
+            follower_id = self.id,
+            followed_id = a_user.id
+        }) ~= nil
+    end,
+    isadmin = function (self)
+        return self.role == 'admin'
+    end,
+    ismoderator = function (self)
+        return self.role == 'moderator'
+    end,
+    isbanned = function (self)
+        return self.role == 'banned'
+    end,
+    is_student = function (self)
+        return self.role == 'student'
+    end,
+    has_min_role = function (self, expected_role)
+        return package.loaded.Users.roles[self.role] >=
+            package.loaded.Users.roles[expected_role]
+    end,
+    has_one_of_roles = function (self, roles)
+        for _, role in pairs(roles) do
+            if self.role == role then
+                return true
+            end
+        end
+        return false
+    end,
+    url_for = function (self, purpose)
+        local urls = {
+            site = '/user?username=' .. escape(self.username)
+        }
+        return urls[purpose]
+    end,
+    logging_params = function (self)
+        -- Identifying info, excluding email (PII)
+        return { id = self.id, username = self.username }
+    end,
+    discourse_email = function (self)
+        if self.unique_email ~= nil and self.unique_email ~= '' then
+            return self.unique_email
+        end
+        return self:ensure_unique_email()
+    end,
+    ensure_unique_email = function (self)
+        -- If a user is new, then their "unique email" is an unmodified email
+        -- address.
+        -- When emails are not unique, we will create a new unique email.
+        -- Unique emails take the form:
+        --                      original-address+snap-id-01234@original.domain
+        local unique_email = self.email
+        if self:shares_email_with_others() then
+            unique_email =
+                string.gsub(self.email, '@', '+snap-id-' .. self.id .. '@')
+        end
+        self:update({ unique_email = unique_email })
+        return unique_email
+    end,
+    shares_email_with_others = function (self)
+        local count = package.loaded.Users:count("unique_email ilike ?", self.email)
+        return count > 0
+    end,
+    cannot_access_forum = function (self)
+        return self:is_student() or self:isbanned() or self.validated == false
+    end
+})
+
+package.loaded.Users = active_users
+
+-- Note: Due to client-side pre-hashing, password length isn't useful...
+package.loaded.Users.validations = {
+    { 'username', exists = true, min_length = 4, max_length = 200 },
+    { 'password', exists = true, min_length = 6 },
+    { 'email', exists = true, min_length = 5 }
+}
+
+package.loaded.Users.roles = {
+    admin = 5,
+    moderator = 4,
+    reviewer = 3,
+    standard = 2,
+    student = 1,
+    banned = 0
+}
+
+package.loaded.DeletedUsers = Model:extend('deleted_users')
+
+-- Used for querires across the entire users table.
+package.loaded.AllUsers = Model:extend('users')
+
+return active_users

--- a/models/users.lua
+++ b/models/users.lua
@@ -176,7 +176,7 @@ ActiveUsers.roles = {
 
 package.loaded.DeletedUsers = Model:extend('deleted_users')
 
--- Used for querires across the entire users table.
+-- Used for queries across the entire users table.
 package.loaded.AllUsers = Model:extend('users')
 
 return ActiveUsers

--- a/writeguardmuter.lua
+++ b/writeguardmuter.lua
@@ -41,7 +41,7 @@ local selectors = {
     'assert_users_have_email', 'assert_project_exists', 'check_token',
     'create_token', 'can_edit_collection', 'assert_collection_exists',
     'assert_can_view_collection', 'assert_can_add_project_to_collection',
-    'assert_can_remove_project_from_collection',
+    'assert_can_remove_project_from_collection', 'assert_can_view_project',
     'assert_project_not_in_collection', 'assert_can_create_collection',
     'course_name_filter', 'hash_password', 'create_signature', 'find_token',
     'rate_limit', 'prevent_tor_access', 'assert_min_role', 'assert_can_share',


### PR DESCRIPTION
So, this PR has no functional changes, and it is admittedly a bit unnecessary, but I do think it's helpful–both for me and hopefully others in the future. :) 

Many of our models are tiny, but I think 1 file per model is helpful, especially for the larger models of users, projects, collections. 
I'm also a fan of annotating the models (semi-)automatically which means you're always aware of what columns are defined on the actual table. 

I added a Makefile which might be an easier way to document commands than just what's in bin. The `install-deps` command could definitely be more generic....