### PR TITLE
Add Dynamic Page Titles for All Pages

### DIFF
--- a/views/admin/carousel_admin.etlua
+++ b/views/admin/carousel_admin.etlua
@@ -1,4 +1,6 @@
 <link rel="stylesheet" href="/static/style/project.css">
+<% content_for('title', 'Carousel Adminstration') %>
+
 <h1>Carousel Administration</h1>
 <%
     for _, section in ipairs({
@@ -64,6 +66,6 @@
                 );
             }
         )
-        
+
     }
 </script>

--- a/views/admin/flags.etlua
+++ b/views/admin/flags.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', 'Flagged Projects') %>
+
 <h1>Flagged Projects</h1>
 <%
 render(

--- a/views/admin/index.etlua
+++ b/views/admin/index.etlua
@@ -1,4 +1,7 @@
 <link rel="stylesheet" href="/static/style/admin.css">
+<% content_for('title', locale.get('administration')) %>
+
+
 <h1><%- locale.get('administration') %></h1>
 
 <div class="admin-buttons">

--- a/views/admin/ip_admin.etlua
+++ b/views/admin/ip_admin.etlua
@@ -1,4 +1,6 @@
 <link rel="stylesheet" href="/static/style/admin.css">
+<% content_for('title', locale.get('suspicious_ips')) %>
+
 <h1><%- locale.get('suspicious_ips') %></h1>
 
 <div class="ips container">

--- a/views/admin/totm.etlua
+++ b/views/admin/totm.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', 'Current Topic of the Month') %>
+
 <h1>Current Topic of the Month</h1>
 
 <div class="row">

--- a/views/admin/user_admin.etlua
+++ b/views/admin/user_admin.etlua
@@ -1,4 +1,6 @@
 <link rel="stylesheet" href="/static/style/admin.css">
+<% content_for('title', 'User Adminstration') %>
+
 <h1>User Administration</h1>
 <%
 render(

--- a/views/admin/zombie_admin.etlua
+++ b/views/admin/zombie_admin.etlua
@@ -1,4 +1,6 @@
 <link rel="stylesheet" href="/static/style/admin.css">
+<% content_for('title', 'Zombie Adminstration') %>
+
 <h1>Zombie Administration</h1>
 <%
 render(

--- a/views/all_totms.etlua
+++ b/views/all_totms.etlua
@@ -1,5 +1,5 @@
+<% content_for('title', locale.get('totms_title')) %>
 <h1><%- locale.get('totms_title') %></h1>
-
 
 <%
 render(

--- a/views/bookmarked.etlua
+++ b/views/bookmarked.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', locale.get('bookmarked_feed')) %>
+
 <h1 class="mb-3"><%= locale.get('bookmarked_feed') %></h1>
 
 <%

--- a/views/change_email.etlua
+++ b/views/change_email.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', locale.get('change_my_email')) %>
+
 <h1><%- locale.get('change_my_email') %></h1>
 <div id="change-email" class="pure-form pure-form-aligned">
     <fieldset>

--- a/views/change_password.etlua
+++ b/views/change_password.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', locale.get('change_password_title')) %>
+
 <h1><%- locale.get('change_password_title') %></h1>
 <div id="change-password" class="pure-form pure-form-aligned">
     <fieldset>

--- a/views/collection.etlua
+++ b/views/collection.etlua
@@ -1,5 +1,9 @@
 <script src="/static/js/project.js"></script>
 <script src="/static/js/inplace.js"></script>
+<% content_for('title',
+    collection.name .. " " .. locale.get('collection_by', collection.creator.username)) %>
+
+
 <link rel="stylesheet" href="/static/style/project.css">
 <div class="collection">
     <div class="title">

--- a/views/collections.etlua
+++ b/views/collections.etlua
@@ -1,10 +1,14 @@
 <% if params.username then %>
+<% content_for('title', locale.get('user_collections_title', params.username)) %>
 <h1><%= locale.get('user_collections_title', params.username) %></h1>
 <% elseif params.search_term then %>
+<% content_for('title', locale.get('collection_search_results', params.search_term)) %>
 <h1><%= locale.get('collection_search_results', params.search_term) %></h1>
 <% else %>
+<% content_for('title', locale.get('collections_title')) %>
 <h1><%= locale.get('collections_title') %></h1>
 <% end %>
+
 <%
 render(
     'views.grid_bs',

--- a/views/delete_user.etlua
+++ b/views/delete_user.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', locale.get('delete_my_user')) %>
+
 <h1 localizable>Delete your Account</h1>
 <h2 localizable>Please confirm your password</h2>
 

--- a/views/events.etlua
+++ b/views/events.etlua
@@ -1,4 +1,6 @@
 <script src="/static/js/project.js"></script>
+<% content_for('title', locale.get('events_title', '<em>!</em>')) %>
+
 <h1 class="mb-3"><%- locale.get('events_title', '<em>!</em>') %></h1>
 
 <%

--- a/views/examples.etlua
+++ b/views/examples.etlua
@@ -1,4 +1,5 @@
 <script src="/static/js/project.js"></script>
+<% content_for('title', locale.get('examples')) %>
 <h1 class="mb-3"><%= locale.get('examples') %></h1>
 
 <%

--- a/views/explore.etlua
+++ b/views/explore.etlua
@@ -1,8 +1,11 @@
 <% if params.username then %>
+<% content_for('title', locale.get('user_projects_title', params.username)) %>
 <h1><%- locale.get('user_projects_title', params.username) %></h1>
 <% elseif params.search_term then %>
+<% content_for('title', locale.get('project_search_results', params.search_term)) %>
 <h1><%- locale.get('project_search_results', params.search_term) %></h1>
 <% else %>
+<% content_for('title', locale.get('explore')) %>
 <h1><%- locale.get('explore') %></h1>
 <% end %>
 <%

--- a/views/followed.etlua
+++ b/views/followed.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('followed_feed')) %>
 <h1 class="mb-3"><%= locale.get('followed_feed') %></h1>
 
 <%

--- a/views/followed_users.etlua
+++ b/views/followed_users.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('followed_users')) %>
 <h1 class="mb-3"><%= locale.get('followed_users') %></h1>
 
 <%

--- a/views/forgot_password.etlua
+++ b/views/forgot_password.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', 'Reset Your Password') %>
 <h1 localizable>Reset Your Password</h1>
 <div id="reset-password" class="pure-form pure-form-aligned">
     <fieldset>

--- a/views/forgot_username.etlua
+++ b/views/forgot_username.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', 'FInd Our Your Username') %>
 <h1 localizable>Find Out Your Username</h1>
 <div id="get-username" class="pure-form pure-form-aligned">
     <fieldset>

--- a/views/header.etlua
+++ b/views/header.etlua
@@ -1,5 +1,9 @@
 <meta charset="UTF-8">
-<title>Snap! Build Your Own Blocks</title>
+<% if has_content_for('title') then %>
+  <title><%= content_for('title') %> | Snap! Build Your Own Blocks</title>
+<% else %>
+  <title>Snap! Build Your Own Blocks</title>
+<% end %>
 
 <meta name="description" content="The Snap! Community. Snap! is a blocks-based programming language built by UC Berkeley and used by hundreds of thousands of programmers around the world.">
 <meta name="author" content="Bernat Romagosa, Michael Ball, Jens Mönig, Brian Harvey, Jadge Hügle">

--- a/views/layout/head_bs.etlua
+++ b/views/layout/head_bs.etlua
@@ -1,5 +1,9 @@
 <meta charset="UTF-8">
-<title>Snap! Build Your Own Blocks</title>
+<% if has_content_for('title') then %>
+  <title><%= content_for('title') %> | Snap! Build Your Own Blocks</title>
+<% else %>
+  <title>Snap! Build Your Own Blocks</title>
+<% end %>
 
 <meta name="description" content="The Snap! Community. Snap! is a blocks-based programming language built by UC Berkeley and used by hundreds of thousands of programmers around the world.">
 <meta name="author" content="Bernat Romagosa, Michael Ball, Jens Mönig, Brian Harvey, Jadge Hügle">

--- a/views/login.etlua
+++ b/views/login.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('log_into_snap', '<em>!</em>')) %>
 <h1><%- locale.get('log_into_snap', '<em>!</em>') %></h1>
 
 <div id="login" class="pure-form pure-form-aligned">

--- a/views/my_collections.etlua
+++ b/views/my_collections.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('my_collections')) %>
 <h1><%- locale.get('my_collections') %></h1>
 <%
 render(

--- a/views/my_followers.etlua
+++ b/views/my_followers.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('follower_users')) %>
 <h1 class="mb-3"><%= locale.get('follower_users') %></h1>
 
 <%

--- a/views/my_projects.etlua
+++ b/views/my_projects.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', locale.get('my_projects')) %>
+
 <h1 class="mb-3"><%- locale.get('my_projects') %></h1>
 
 <%

--- a/views/my_projects.etlua
+++ b/views/my_projects.etlua
@@ -1,5 +1,4 @@
 <% content_for('title', locale.get('my_projects')) %>
-
 <h1 class="mb-3"><%- locale.get('my_projects') %></h1>
 
 <%

--- a/views/profile.etlua
+++ b/views/profile.etlua
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="/static/style/profile.css">
+<% content_for('title', locale.get('profile_title', user.username)) %>
 <h1><%- locale.get('profile_title', user.username) %></h1>
 <div class="pure-g profile">
     <div class="pure-u-1-2 fields">

--- a/views/project_bs.etlua
+++ b/views/project_bs.etlua
@@ -1,5 +1,5 @@
 <!-- <script src="/static/js/inplace.js"></script> -->
-
+<% content_for('title', project.projectname .. " " .. locale.get('project_by', project.username)) %>
 
 <!-- TODO-BS: Replace .project.big with a single CSS class. Extract to partial? -->
 <div class="project big mt-3">

--- a/views/search.etlua
+++ b/views/search.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('search_results', params.query)) %>
 <h1><%= locale.get('search_results', params.query) %></h1>
 
 <%

--- a/views/sign_up.etlua
+++ b/views/sign_up.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('signup_title', '<em>!</em>')) %>
 <h1><%- locale.get('signup_title', '<em>!</em>') %></h1>
 <div id="signup" class="pure-form pure-form-aligned">
     <fieldset>
@@ -134,4 +135,3 @@
         };
     </script>
 </div>
-

--- a/views/static/about.etlua
+++ b/views/static/about.etlua
@@ -1,4 +1,6 @@
+<% content_for('title', 'About') %>
 <h1 localizable>About Snap<em>!</em></h1>
+
 <p>Snap<em>!</em> (formerly BYOB) is a visual, drag-and-drop programming language. It is an extended reimplementation of <a href="https://scratch.mit.edu/">Scratch</a> (a project of the <a href="https://llk.media.mit.edu/">Lifelong Kindergarten Group</a> at the <a href="https://media.mit.edu/">MIT Media Lab</a>) that allows you to Build Your Own Blocks. It also features first class<sup><a href="#firstclass">[1]</a></sup> lists, first class procedures, and first class continuations<sup><a href="#continuations">[2]</a></sup>. These added capabilities make it suitable for a serious introduction to computer science for high school or college students.</p>
 
 <p>In the example below, a Snap<em>!</em> user can create new control structures, such as a <code>for</code> loop, by writing a script as shown at the left. Once the <code>for</code> block is created, it can be used even to make nested loops, as shown in the center. A sprite carries out that script at the right.</p> </section>

--- a/views/static/bjc.etlua
+++ b/views/static/bjc.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('bjc')) %>
 <h1 localizable>The Beauty and Joy of Computing</h1>
 
 <span><p>The Beauty and Joy of Computing (BJC) is an introductory computer science curriculum using Snap<em>!</em>, developed at the University of California, Berkeley and Education Development Center, Inc., intended for non-CS majors at the high school junior through undergraduate freshman level. It is a College Board-endorsed AP CS Principles course. It is offered as CS10 at Berkeley.</p></span>

--- a/views/static/blog.etlua
+++ b/views/static/blog.etlua
@@ -1,9 +1,10 @@
 <script src="/static/js/discourse.js"></script>
 <link rel="stylesheet" href="/static/style/blog.css">
 
+<% content_for('title', 'Blog') %>
 <h1>Blog</h1>
-<div class="blog"></div>
 
+<div class="blog"></div>
 <script>
     new DiscourseBlog(
         'https://forum.snap.berkeley.edu',

--- a/views/static/coc.etlua
+++ b/views/static/coc.etlua
@@ -1,2 +1,3 @@
+<% content_for('title', 'Code of Conduct') %>
 <h1>Code of Conduct</h1>
 <span>ToDo</span>

--- a/views/static/contact.etlua
+++ b/views/static/contact.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', 'Contact') %>
 <h1 localizable>Contact</h1>
 <p>You can contact the development team at:</p>
 

--- a/views/static/credits.etlua
+++ b/views/static/credits.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', 'Credits') %>
 <h1 localizable>Credits</h1>
 <h2>Snap<em>!</em> - Build Your Own Blocks</h2>
 <p>Snap<em>!</em> is inspired by <a href="https://scratch.mit.edu"

--- a/views/static/dmca.etlua
+++ b/views/static/dmca.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', 'DMCA Policy') %>
 <h1 localizable>DMCA Policy</h1>
 
 <p>The University of California respects the intellectual property of others, as well as our users. If you believe that your work has been copied in a way that constitutes copyright infringement, please email <a href="mailto:contact+dmca@snap.berkeley.edu">contact+dmca@snap.berkeley.edu</a>, or mail your complaint to the following:</p>

--- a/views/static/extensions.etlua
+++ b/views/static/extensions.etlua
@@ -1,5 +1,7 @@
+<% content_for('title', 'Extensions') %>
 <h1 localizable>Extensions</h1>
-<h3>Use devices with Snap<em>!</em>:</h3>
+
+<h2>Use devices with Snap<em>!</em>:</h2>
 <ul class="indent">
     <li>BBC <a href="https://snap.berkeley.edu/snap/snap.html#cloud:Username=birdbraintech&ProjectName=MicrobitStarterProject">micro:bit</a> bluetooth package by Krissie Lauwers.</li>
     <li>Orbotix <a href="https://docs.google.com/document/d/11wR53OTnofRtTtxZCmxnCUjIlFQjnGewM21A0vmjtFw/edit?usp=sharing">Sphero</a> guide by Connor Hudson and Dan Garcia.</li>
@@ -16,7 +18,7 @@
     <li><a href="https://github.com/rasplay/PiSnap_Project">Snap<em>!</em> for Raspberry Pi</a> by Rasplay.</li>
 </ul>
 
-<h3>More Snap<em>!</em> extensions for CS education</h3>
+<h2>More Snap<em>!</em> extensions for CS education</h2>
 <ul class="indent">
     <li><a href="http://beetleblocks.com">Beetle Blocks</a> is a complete Snap<em>!</em> modification for 3D design and fabrication.</li>
     <li><a href="http://turtlestitch.org">TurtleStitch</a> lets you generate patterns for embroidery machines.</li>
@@ -27,7 +29,7 @@
     <li><a href="https://progkids.ru">ProgKids</a> is a Snap<em>!</em> extension that lets you program MineCraft (in Russian).</li>
 </ul>
 
-<h3>Tools</h3>
+<h2>Tools</h2>
 <ul class="indent">
     <li>Turn your project into a standalone executable with <a target="_blank" href="http://snapp.citilab.eu">Snapp<em>!</em>.</a></li>
     <li>Import Scratch 2.0 projects with <a target="_blank" href="https://djsrv.github.io/Snapin8r2/">Snapin8r2</a>.</li>

--- a/views/static/materials.etlua
+++ b/views/static/materials.etlua
@@ -1,4 +1,6 @@
+<% content_for('title', 'Materials') %>
 <h1 localizable>Materials</h1>
+
 <div class="materials"></div>
 <h2>MOOCS and Online Courses</h2>
 <ul>

--- a/views/static/mirrors.etlua
+++ b/views/static/mirrors.etlua
@@ -1,4 +1,6 @@
+<% content_for('title', 'Mirrors') %>
 <h1>Mirrors</h1>
+
 <p>If <em>snap.berkeley.edu</em> is ever unavailable, you can run Snap<em>!</em> at any of these mirror sites:</p>
 <p class="indent"><a href="http://bjc.edc.org/snapsource/snap.html">http://bjc.edc.org/snapsource/snap.html</a></p>
 <p class="indent"><a href="https://media.mit.edu/~harveyb/snap">https://media.mit.edu/~harveyb/snap</a></p>

--- a/views/static/offline.etlua
+++ b/views/static/offline.etlua
@@ -1,4 +1,6 @@
-<h1 tabindex="-1">Using Snap! Without an Internet Connection</h1>
+<% content_for('title', locale.get('offline')) %>
+<h1>Using Snap! Without an Internet Connection</h1>
+
 <p>last updated on Nov. 25, 2021</p>
 <p>Snap! is a web application hosted at
 <a href="https://snap.berkeley.edu/run" title="Snap! online" rel="nofollow">https://snap.berkeley.edu/run</a>.</p>

--- a/views/static/partners.etlua
+++ b/views/static/partners.etlua
@@ -1,4 +1,6 @@
+<% content_for('title', 'Partners, Sponsors, and Collaborators') %>
 <h1 localizable>Partners, sponsors and collaborators</h1>
+
 <ul class="flex list-unstyled">
     <!-- TODO: Cleanup this list. Include UC Berkeley? -->
     <li>

--- a/views/static/privacy.etlua
+++ b/views/static/privacy.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', 'Privacy Policy') %>
 <h1 localizable><img src="/static/img/Logo5.png" alt="Snap!" height="30px"> Privacy Policy</h1>
 
 <p>Your privacy and safety online are very important to us. To protect your privacy, we limit what we collect and what we publish on the website. Although, as a nonprofit educational institution, we are technically exempt from the United States Children's Online Privacy Protection Act (COPPA), we are voluntarily following its rules about data collection from children under 13.  This policy also conforms to the European Union General Data Protection Regulation (GDPR), which restricts data collection from children under 16.  We apply these protection policies to all users, wherever located, so 16 is our cutoff age for parental notification.</p>

--- a/views/static/requirements.etlua
+++ b/views/static/requirements.etlua
@@ -1,4 +1,6 @@
+<% content_for('title', 'Techinical Requirements') %>
 <h1 localizable>Technical Requirements</h1>
+
 <div class="pure-g">
     <div class="pure-u-1-12"><strong>Browser</strong></div><div class="pure-u-1-6"><strong>Minimum Version</strong></div><div class="pure-u-3-4"><strong>Additional Notes</strong></div>
     <div class="pure-u-1-12">Chrome</div><div class="pure-u-1-6">43</div><div class="pure-u-3-4">Chrome is currently the <em>recommended</em> browser for Snap<em>!</em></div>

--- a/views/static/research.etlua
+++ b/views/static/research.etlua
@@ -1,5 +1,7 @@
 <link rel="stylesheet" href="/static/style/research.css">
+<% content_for('title', 'Research') %>
 <h1>Research</h1>
+
 <ul class="article-list">
     <li>
         <a href="/static/doc/Kolar Moser Goldenberg—Building a Microworld in Snap.pdf" target="_blank" class="article-title">Building a Microworld in Snap<em>!</em></a>

--- a/views/static/snapinator.etlua
+++ b/views/static/snapinator.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', 'Snapinator') %>
 <h1>Snapinator</h1>
 <p>Snapinator is an external web service from Deborah Servilla that translates a Scratch project into a Snap<em>!</em> one. Please note that while we love Snapinator it is currently not part of Snap<em>!</em> and not maintained by the Snap<em>!</em> dev team.</p>
 <h4><a href="https://snapinator.github.io/">https://snapinator.github.io/</a></h4>

--- a/views/static/snapp.etlua
+++ b/views/static/snapp.etlua
@@ -1,3 +1,5 @@
+<% content_for('title', 'Snapp') %>
 <h1>Snapp</h1>
+
 <p>Snapp is an external web service that packages a Snap<em>!</em> project as a stand-alone executable for different operating systems. Please note that while we love Snapp it is currently not part of Snap<em>!</em> and not maintained by the Snap<em>!</em> dev team. Also, Snapp might not support the latest additions and features of Snap<em>!</em>.</p>
 <h4><a href="http://snapp.citilab.eu/">http://snapp.citilab.eu/</a></h4>

--- a/views/static/source.etlua
+++ b/views/static/source.etlua
@@ -1,4 +1,6 @@
+<% content_for('title', 'Source Code') %>
 <h1>Source Code</h1>
+
 <span><p>All components of the Snap<em>!</em> Programming System are free and open source under a GNU General Public License. You are welcome to explore and tinker with our code, to remix, extend and share.</p></span>
 <h2>The Snap<em>!</em> programming language/environment</h2>
 <span><p>IDE and the Snap<em>!</em> runtime environment, including the graphical blocks, widgets, evaluator and timesharing multiplexer.</p></span>

--- a/views/static/tos.etlua
+++ b/views/static/tos.etlua
@@ -1,3 +1,4 @@
+<% content_for('title', locale.get('tos')) %>
 <h1 localizable>Terms of Service</h1>
 
 <p>Welcome to the <img src="static/img/small-logo.png" alt="Snap!" height="20px"> user community!</p>

--- a/views/user.etlua
+++ b/views/user.etlua
@@ -2,6 +2,7 @@
 <link rel="stylesheet" href="/static/style/admin.css">
 <% end %>
 
+<% content_for('title', locale.get('public_page', username)) %>
 <h1><%= locale.get('public_page', username) %></h1>
 
 <%

--- a/views/user.etlua
+++ b/views/user.etlua
@@ -62,7 +62,7 @@ end
 
 <% if current_user and current_user:has_min_role('moderator') then %>
 <!-- -- ADMIN TOOLS -->
-<div class="col-4">
+<div class="col-4 col-sm-12">
     <h2><%- locale.get('admin_tools') %></h2>
 <%
     render(

--- a/views/users.etlua
+++ b/views/users.etlua
@@ -1,6 +1,8 @@
 <% if params.search_term ~= '' then %>
+<% content_for('title', locale.get('user_search_results', params.search_term)) %>
 <h1><%= locale.get('user_search_results', params.search_term) %></h1>
 <% else %>
+<% content_for('title', locale.get('last_users')) %>
 <h1><%= locale.get('last_users') %></h1>
 <% end %>
 <%


### PR DESCRIPTION
Use `content_for('title', 'title content')` to set the page title.

Tries to use localized titles where possible.

- **Setup Page-sepcific titles.**
- **Set a title all pages**
- **Fix admin user card size on mobile**
- **Add page titles to all static pages**
