### PR TITLE
Ability to Join a Collection via a Join Code

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -248,7 +248,6 @@ app:match(api_route('project/:id'), respond_to({
     DELETE = ProjectController.delete
 }))
 
-
 -- [LEGACY]
 -- Legacy API calls by username and projectname. Used by the editor and mods.
 
@@ -347,6 +346,12 @@ app:match(api_route('collection/:id/project/:project_id'),
         DELETE = CollectionController.remove_project
     })
 )
+
+app:match(api_route('collection/:id/join_token'), respond_to({
+    GET = CollectionController.get_join_token,
+    POST = CollectionController.get_join_token,
+    DELETE = CollectionController.remove_join_token
+}))
 
 -- Site
 -- ====

--- a/app.lua
+++ b/app.lua
@@ -167,17 +167,6 @@ package.loaded.uncache_category = function (category)
     if query then ngx.shared.query_cache:delete(query) end
 end
 
---- DEBUGGING
-app:before_filter(function(self)
-    print("Request path:", self.req.path)
-    print("Params:", require('lapis.util').to_json(self.params))
-end)
-
-app:get('/*', function(self)
-    print("Unmatched route:", self.req.path)
-    return { status = 404, render = 'error', message = 'Route not found' }
-end)
-
 -- Before filter
 app:before_filter(function (self)
     -- Temporarily disable IP bans because of too many false positives

--- a/app.lua
+++ b/app.lua
@@ -167,6 +167,17 @@ package.loaded.uncache_category = function (category)
     if query then ngx.shared.query_cache:delete(query) end
 end
 
+--- DEBUGGING
+app:before_filter(function(self)
+    print("Request path:", self.req.path)
+    print("Params:", require('lapis.util').to_json(self.params))
+end)
+
+app:get('/*', function(self)
+    print("Unmatched route:", self.req.path)
+    return { status = 404, render = 'error', message = 'Route not found' }
+end)
+
 -- Before filter
 app:before_filter(function (self)
     -- Temporarily disable IP bans because of too many false positives

--- a/controllers/collection.lua
+++ b/controllers/collection.lua
@@ -427,7 +427,7 @@ CollectionController = {
             assert_admin(self)
         end
         -- TODO: Would be better to have a model method for this
-        -- URL safe characters: 1-9, A-Z, a-z, - _ . ~, except: l, I, O,
+        -- URL safe characters: 1-9, A-Z, a-z, -, _, ~, except: l, I, O,
         if not collection.join_token then
             local charset = {}
             -- Add 1-9
@@ -448,7 +448,6 @@ CollectionController = {
             end
             table.insert(charset, '-')
             table.insert(charset, '_')
-            table.insert(charset, '.')
             table.insert(charset, '~')
             math.randomseed(os.time() + collection.id)
             local token = {}

--- a/controllers/collection.lua
+++ b/controllers/collection.lua
@@ -419,13 +419,13 @@ CollectionController = {
     -- Get or generate a join token for a collection
     get_join_token = capture_errors(function (self)
         local collection = Collections:find({ id = self.params.id })
-        assert(collection, 'Collection not found')
 
         -- TODO: assert creator or admin function
         if (self.current_user == nil) or
               (collection.creator_id ~= self.current_user.id) then
             assert_admin(self)
         end
+
         -- TODO: Would be better to have a model method for this
         -- URL safe characters: 1-9, A-Z, a-z, -, _, ~, except: l, I, O,
         if not collection.join_token then

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -236,7 +236,8 @@ CREATE TABLE public.collections (
     shared_at timestamp with time zone,
     thumbnail_id integer,
     editor_ids integer[],
-    free_for_all boolean DEFAULT false NOT NULL
+    free_for_all boolean DEFAULT false NOT NULL,
+    join_token text
 );
 
 
@@ -518,6 +519,14 @@ ALTER TABLE ONLY public.collection_memberships
 
 
 --
+-- Name: collections collections_join_token_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.collections
+    ADD CONSTRAINT collections_join_token_key UNIQUE (join_token);
+
+
+--
 -- Name: collections collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -737,6 +746,7 @@ COPY public.lapis_migrations (name) FROM stdin;
 2023-03-14:1
 2025-02-06:0
 2025-06-18:0
+2025-09-04:0
 \.
 
 

--- a/migrations.lua
+++ b/migrations.lua
@@ -348,4 +348,14 @@ return {
         update_user_views()
         update_project_views()
     end,
+
+    -- Add join_token column to collections
+    ['2025-09-04:0'] = function ()
+        schema.add_column(
+            'collections',
+            'join_token',
+            types.text({ null = true, unique = true })
+        )
+    end,
+
 }

--- a/models/collections.lua
+++ b/models/collections.lua
@@ -60,7 +60,8 @@ local Collections =  Model:extend('collections', {
         local urls = {
             site = '/collection?username=' .. escape(self.username) ..
                 '&collection=' .. escape(self.name),
-            author = '/user?username=' .. escape(self.username)
+            author = '/user?username=' .. escape(self.username),
+            join = '/collection/' .. escape(self.join_token or '') .. '/join'
         }
         return urls[purpose]
     end,

--- a/site.lua
+++ b/site.lua
@@ -206,6 +206,36 @@ app:get('/collection', capture_errors(function (self)
     return { render = 'collection' }
 end))
 
+app:get('/collection/:token/join', capture_errors(function (self)
+    assert_user_exists(self)
+    self.collection = Collections:find({ join_token = self.params.token })
+    assert_exists(self.collection, 'Collection not found')
+
+    if not self.current_user then
+        return errorResponse(self,
+            'You must be logged in to join a collection.',
+            403)
+    end
+
+    if not self.collection.editor_ids then
+        self.collection.editor_ids = {}
+    end
+    local editor_ids = self.collection.editor_ids
+    local already_editor = false
+    for _, id in pairs(editor_ids) do
+        if id == self.current_user.id then
+            already_editor = true
+            break
+        end
+    end
+    if not already_editor then
+        table.insert(editor_ids, self.current_user.id)
+        Collections:update({ id = self.collection.id }, { editor_ids = db.raw('ARRAY[' .. table.concat(editor_ids, ',') .. ']') })
+    end
+
+    return jsonResponse({ redirect = self.collection:url_for('site') })
+end))
+
 app:get('/user', capture_errors(function (self)
     assert_user_exists(self)
     self.username = self.queried_user.username

--- a/views/partials/collection_info.etlua
+++ b/views/partials/collection_info.etlua
@@ -42,3 +42,32 @@
          render('views.partials.collection_buttons')
     end
 %>
+
+<% if current_user and (current_user.id == collection.creator_id or current_user:isadmin()) then %>
+    <div class="join-token-controls mt-3">
+        <label class="form-label"><%= locale.get('join_token_label') or 'Join Token:' %></label>
+        <% if collection.join_token then %>
+            <div class="input-group mb-2">
+                <input type="text" class="form-control" id="join-token" value="<%= collection.join_token %>" readonly>
+                <button class="btn btn-outline-secondary" type="button" onclick="copyJoinUrl()">Copy Join URL</button>
+                <button class="btn btn-outline-danger" type="button" onclick="removeJoinToken()">Remove Join URL</button>
+            </div>
+        <% else %>
+            <button class="btn btn-outline-primary" type="button" onclick="generateJoinToken()">Generate Join URL</button>
+        <% end %>
+    </div>
+    <script>
+    function copyJoinUrl() {
+        const token = document.getElementById('join-token').value;
+        const url = window.location.origin + "<%= collection:url_for('join') %>";
+        navigator.clipboard.writeText(url);
+        // alert('Join URL copied to clipboard!');
+    }
+    function removeJoinToken() {
+        cloud.apiRequest('DELETE', '/api/v1/collection/<%= collection.id %>/join_token', (resp) => { location.reload(); });
+    }
+    function generateJoinToken() {
+        cloud.apiRequest('GET', '/api/v1/collection/<%= collection.id %>/join_token', (resp) => { location.reload(); });
+    }
+    </script>
+<% end %>


### PR DESCRIPTION
For admins and collection owners.

* Create a short join token which can be given to users to "add themselves" to a collection 
* Create a token by clicking the button, then copy the URL
* Turn it off by deleting the token.

Mostly so that we can use this for Snap!Con. Maybe teachers will want to use it for a classroom? Or we can we use the same thing for groups.

<img width="470" height="772" alt="Screenshot 2025-09-04 at 3 15 47 AM" src="https://github.com/user-attachments/assets/f32db08e-cc78-4223-a62b-4fe4e1cfc3af" />
<img width="476" height="787" alt="Screenshot 2025-09-04 at 3 15 35 AM" src="https://github.com/user-attachments/assets/44eb16cd-f33c-4a37-89ed-ac81a125bc52" />


---

With a pretty clear prompt, Co-Pilot (Chat GPT 4.1) did OK with generating many of the components, but put them all in very stupid places and doesn't understand lapis. It generated bad SQL, and invented a good handful of functions that didn't exist in lapis/snapCloud, but was reasonable at generating the HTML/JS with only mild style improvements and tweaks to how our cloud JS API is defined. 