### PR TITLE
Refactor session_count to accurately reflect sessions, not logins, and add last_session_at timestamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ static/img/totm.png
 
 # local JS tools
 node_modules/
+
+# Database backups and dumps
+*.dump
+*.db
+*.sql
+!db/*.sql

--- a/app.lua
+++ b/app.lua
@@ -250,6 +250,29 @@ app:before_filter(function (self)
         self.current_user =
             package.loaded.Users:find({ username = self.session.username })
         self.session.last_access_at = date(true):fmt('${http}')
+
+        -- Track distinct sessions: increment session_count and update
+        -- last_session_at at most once every 4 hours.
+        if self.current_user then
+            local should_count_session = false
+            if not self.current_user.last_session_at then
+                should_count_session = true
+            else
+                local hours_since = package.loaded.db.select(
+                    "extract(epoch from now() - ?::timestamptz) / 3600 as hours",
+                    self.current_user.last_session_at
+                )[1]
+                if hours_since.hours >= 4 then
+                    should_count_session = true
+                end
+            end
+            if should_count_session then
+                self.current_user:update({
+                    last_session_at = package.loaded.db.format_date(),
+                    session_count = self.current_user.session_count + 1
+                })
+            end
+        end
     else
         self.session.username = ''
         self.current_user = nil

--- a/controllers/user.lua
+++ b/controllers/user.lua
@@ -135,8 +135,7 @@ UserController = {
                 if self.queried_user:is_student() then
                     self.queried_user:update({
                         verified = true,
-                        last_login_at = db.format_date(),
-                        session_count = self.queried_user.session_count + 1
+                        last_login_at = db.format_date()
                     })
                     return jsonResponse({
                         title = 'Welcome to Snap!',
@@ -174,8 +173,7 @@ UserController = {
             self.session.username = self.queried_user.username
             self.session.persist_session = tostring(self.params.persist)
             self.queried_user:update({
-                last_login_at = db.format_date(),
-                session_count = self.queried_user.session_count + 1
+                last_login_at = db.format_date()
             })
             if self.queried_user.verified then
                 return okResponse('User ' .. self.queried_user.username

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -131,7 +131,8 @@ CREATE TABLE public.users (
     is_teacher boolean DEFAULT false NOT NULL,
     creator_id integer,
     last_login_at timestamp with time zone,
-    session_count integer DEFAULT 0 NOT NULL
+    session_count integer DEFAULT 0 NOT NULL,
+    last_session_at timestamp with time zone
 );
 
 
@@ -156,7 +157,8 @@ CREATE VIEW public.active_users AS
     is_teacher,
     creator_id,
     last_login_at,
-    session_count
+    session_count,
+    last_session_at
    FROM public.users
   WHERE (deleted IS NULL);
 
@@ -313,7 +315,8 @@ CREATE VIEW public.deleted_users AS
     is_teacher,
     creator_id,
     last_login_at,
-    session_count
+    session_count,
+    last_session_at
    FROM public.users
   WHERE (deleted IS NOT NULL);
 

--- a/migrations.lua
+++ b/migrations.lua
@@ -358,18 +358,6 @@ return {
         )
     end,
 
-    -- Add last_session_at column to users
-    -- Refactor session_count to track distinct sessions (4-hour window)
-    -- rather than login events
-    ['2026-04-06:0'] = function ()
-        schema.add_column(
-            'users',
-            'last_session_at',
-            types.time({ timezone = true, null = true })
-        )
-        update_user_views()
-    end,
-
   -- Add password_changed_at and updated_at columns to users
     ['2026-04-06:0'] = function ()
         schema.add_column(
@@ -380,6 +368,18 @@ return {
         schema.add_column(
             'users',
             'updated_at',
+            types.time({ timezone = true, null = true })
+        )
+        update_user_views()
+    end,
+
+    -- Add last_session_at column to users
+    -- Refactor session_count to track distinct sessions (4-hour window)
+    -- rather than login events
+    ['2026-04-06:2'] = function ()
+        schema.add_column(
+            'users',
+            'last_session_at',
             types.time({ timezone = true, null = true })
         )
         update_user_views()

--- a/migrations.lua
+++ b/migrations.lua
@@ -358,4 +358,16 @@ return {
         )
     end,
 
+    -- Add last_session_at column to users
+    -- Refactor session_count to track distinct sessions (4-hour window)
+    -- rather than login events
+    ['2026-04-06:0'] = function ()
+        schema.add_column(
+            'users',
+            'last_session_at',
+            types.time({ timezone = true, null = true })
+        )
+        update_user_views()
+    end,
+
 }


### PR DESCRIPTION
## Refactor session tracking to use distinct 4-hour windows instead of login events

This PR decouples `session_count` from login events so it accurately reflects user sessions rather than authentication actions. A new `last_session_at` timestamp column is introduced to track when the most recent session window began.

## Changes

- **`migrations.lua`**: Adds migration `2026-04-06:0` to add a `last_session_at` (`timestamptz`, nullable) column to the `users` table and refreshes the user views.
- **`app.lua`**: Adds session tracking logic in the `before_filter` that runs on every authenticated request — increments `session_count` and updates `last_session_at` only if `last_session_at` is null (first ever session) or 4+ hours have elapsed since the last recorded session.
- **`controllers/user.lua`**: Removes `session_count` increments from both login paths (student first-login and standard login). `last_login_at` continues to be updated only on actual authentication events.
- **`db/schema.sql`**: Adds `last_session_at` column to the `users` table definition and both the `active_users` and `deleted_users` views.

## Architecture Overview

Previously, `session_count` was incremented directly in the login controller, making it effectively a login counter. The new approach moves session tracking to the `before_filter` in `app.lua`, which runs on every authenticated request. By comparing the current time against `last_session_at`, the system ensures at most one session is counted per 4-hour window, regardless of how many times a user logs in or out during that period.

| Field | Behavior After This PR |
|---|---|
| `last_login_at` | Updated only when a user authenticates (logs in) |
| `session_count` | Incremented at most once per 4-hour window on any authenticated request |
| `last_session_at` | Records the timestamp when the current session window began |

## Reviewer Notes

- The 4-hour window is calculated server-side using a PostgreSQL `extract(epoch ...)` query to avoid any clock skew issues between application and database.
- Existing `session_count` values in production will remain as-is; they will continue incrementing under the new (more conservative) logic going forward.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/LDFkrLKqffNm/implementations/tK7jMcJhRtPG) | [Guided Review](https://www.superconductor.com/tickets/LDFkrLKqffNm/implementations/tK7jMcJhRtPG?tab=guided_review)

<!-- created-by-superconductor -->