### PR TITLE
Fix: Sentry error - attempt to call method 'match' (a nil value) in responses.lua

### DIFF
--- a/responses.lua
+++ b/responses.lua
@@ -73,7 +73,10 @@ local html_error = function (self, error, status)
 end
 
 errorResponse = function (self, err, status)
-    local is_html_page = (self.req.headers['accept'] or ''):match('text/html')
+    local headers = self.req and self.req.headers
+    local accept = headers and headers['accept'] or ''
+    if type(accept) == 'table' then accept = table.concat(accept, ',') end
+    local is_html_page = accept:match('text/html')
     if is_html_page then
         return html_error(self, err, status)
     else


### PR DESCRIPTION
## Fix crash when `Accept` header is duplicated in requests

Fixes a Sentry-reported production error where `responses.lua:76` crashed with "attempt to call method 'match' (a nil value)" when clients sent multiple `Accept` headers in a single request.

## Changes

- **Root cause fix**: When a client sends duplicate `Accept` headers, OpenResty returns a Lua table instead of a string. Since a table is truthy, the `or ''` fallback never triggered, and calling `:match()` on a table caused the crash. The fix detects this case and joins the table values with a comma before matching.
- **Defensive guard**: Added nil checks for `self.req` and `self.req.headers` to safely handle cases where the request context may be absent during error-handler execution.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/8PQtmP6bqQ7m/implementations/RqgFDTbJw9LG) | [App Preview](https://www.superconductor.com/tickets/8PQtmP6bqQ7m/implementations/RqgFDTbJw9LG/preview) | [Guided Review](https://www.superconductor.com/tickets/8PQtmP6bqQ7m/implementations/RqgFDTbJw9LG?tab=guided_review)

<!-- created-by-superconductor -->