### PR TITLE
Investigate and fix nil value error during password hashing

### DIFF
--- a/passwords.lua
+++ b/passwords.lua
@@ -95,6 +95,13 @@ end
 -- @param password_version number  The users.password_version value (0, 1, 2).
 -- @return boolean  true if the password matches.
 verify_password = function (prehash, stored_hash, salt, password_version)
+    -- A missing prehash (e.g. a login POST with no password field) must be
+    -- treated as a failed authentication, not a 500. Bailing here prevents
+    -- the nil from reaching hash_password's string concat or bcrypt.verify.
+    if prehash == nil or stored_hash == nil then
+        return false
+    end
+
     local version = password_version or PASSWORD_VERSION_LEGACY
 
     if version == PASSWORD_VERSION_LEGACY then


### PR DESCRIPTION
## Fix nil password crash during login

Guards `verify_password` against nil inputs so a login POST missing the `password` field returns an authentication failure instead of crashing with a 500 error.

## Changes

- Added a nil check at the top of `verify_password` in `passwords.lua` that returns `false` early if `prehash` or `stored_hash` is nil
- Prevents the nil value from reaching the string concatenation in `hash_password`, which was causing the reported Sentry crash
- All four `verify_password` call sites (login, change_email, change_password, delete) now correctly surface this as a `wrong_password` error rather than a 500

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/HFF8wwpbdbpJ/implementations/fbtqbbzTpW6M) | [App Preview](https://www.superconductor.com/tickets/HFF8wwpbdbpJ/implementations/fbtqbbzTpW6M/preview) | [Guided Review](https://www.superconductor.com/tickets/HFF8wwpbdbpJ/implementations/fbtqbbzTpW6M?tab=guided_review)

<!-- created-by-superconductor -->