### PR TITLE
Fix: Handle nil comparison error in app.lua during user API request

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -123,16 +123,11 @@ end
 -- after a request has been authenticated and current_user is set.
 local function track_session_activity(self)
     local should_count_session = false
-    if not self.current_user.last_session_at then
+    local last_session_at = self.current_user.last_session_at
+    if not last_session_at then
         should_count_session = true
-    else
-        local hours_since = package.loaded.db.select(
-            "extract(epoch from now() - ?::timestamptz) / 3600 as hours",
-            self.current_user.last_session_at
-        )[1]
-        if hours_since.hours >= 4 then
-            should_count_session = true
-        end
+    elseif (date(true) - date(last_session_at)):spanhours() >= 4 then
+        should_count_session = true
     end
     if should_count_session then
         self.current_user:update({


### PR DESCRIPTION
## Fix nil comparison crash in session filter (`app.lua:265`)

Resolves a Sentry-reported crash where the before-filter threw `attempt to compare nil with number` when checking how long ago a user's last session occurred.

## Changes

- Replaces a database query (`extract(epoch from now() - ...)`) with an equivalent in-Lua calculation using the already-imported `date` library
- Fixes the crash: pgmoon omits NULL columns from result rows, so `hours_since.hours` was `nil` when the DB returned NULL, causing the comparison to fail
- Removes a redundant DB query from every authenticated request, slightly improving performance

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/L9kMDpMdLrgH/implementations/mnnNn7CKThcN) | [App Preview](https://www.superconductor.com/tickets/L9kMDpMdLrgH/implementations/mnnNn7CKThcN/preview) | [Guided Review](https://www.superconductor.com/tickets/L9kMDpMdLrgH/implementations/mnnNn7CKThcN?tab=guided_review)

<!-- created-by-superconductor -->