### PR TITLE
Setup gzip compression for Snap! IDE and deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ node_modules/
 *.sql.gz
 # Keep the specific schema and init files in db/
 !db/*.sql
+
+# Pre-compressed static assets produced by bin/compress (run on the server
+# at deploy time). The .sql.gz rule above already covers backups.
+static/**/*.gz

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,175 @@
+# Snap!Cloud Deployment Guide
+
+This guide covers production-only deployment concerns. For local
+development setup see [`INSTALL.md`](./INSTALL.md).
+
+## Snap! checkouts on the server
+
+The production server keeps several independent Snap! checkouts. They are
+served from the locations defined in [`nginx.conf.d/snap-ide.conf`](./nginx.conf.d/snap-ide.conf):
+
+| Path on disk            | Served at              | Tracks                                  |
+| ----------------------- | ---------------------- | --------------------------------------- |
+| `~/snapCloud/snap/`     | `/snap/`               | The latest tagged Snap! release         |
+| `~/snap-versions/dev/`  | `/versions/dev/`       | `origin/master` (development version)   |
+| `~/snap-versions/previous/` | `/versions/previous/` | A pinned older tag (see `bin/update-snap`) |
+
+`bin/update-snap` is the entry point for refreshing all three: it
+`git fetch`es each checkout, switches to the right ref, and then runs
+`bin/compress` against the checkout to produce `.gz` siblings of every
+text asset.
+
+`bin/deploy` does the equivalent for `~/snapCloud/static/` itself.
+
+## gzip configuration
+
+Gzip is configured **once**, at the `http { }` level in
+[`nginx.conf`](./nginx.conf):
+
+```nginx
+gzip on;              # on-the-fly compression for dynamic responses
+gzip_static on;       # serve a precompressed .gz sibling when present
+gzip_min_length 1000; # don't bother for tiny responses
+gzip_proxied any;
+gzip_vary on;
+gzip_comp_level 6;
+gzip_types *;
+```
+
+Because these directives live at the http level, every server / location
+inherits them — including:
+
+- `/snap/` and `/versions/` — Snap! checkouts, pre-compressed by
+  `bin/compress`. `gzip_static` serves the `.gz` directly.
+- `/static/` — Snap!Cloud's own CSS/JS/SVG, pre-compressed by
+  `bin/compress` during `bin/deploy`.
+- `/api/v1/` and `@lapisapp` — lapis dynamic responses (JSON, HTML).
+  No `.gz` exists, so `gzip on` compresses them on the fly. This
+  covers the large JSON payloads (project listings etc.) that can
+  exceed 1 MB.
+- `/`, `/old_site`, `/js-extensions` — any other static aliases.
+
+### What is NOT pre-compressed
+
+`bin/compress` deliberately skips `.html` files and `sw.js`. The
+`/snap/` and `/versions/` locations use `sub_filter <head> $cloud_loc;`
+to inject a `<meta name="snap-cloud-domain">` tag at runtime, and
+`gzip_static` would serve the .gz before `sub_filter` could touch the
+response — silently dropping the substitution. nginx still gzips these
+files dynamically via `gzip on`.
+
+### `gzip_static` requirements
+
+`gzip_static` requires the `ngx_http_gzip_static_module`. OpenResty —
+which is what `bin/prereqs.sh` installs — ships with it enabled. If you
+build nginx from source, pass `--with-http_gzip_static_module`.
+
+## When pre-compression runs
+
+| Trigger             | Compresses                                       |
+| ------------------- | ------------------------------------------------ |
+| `bin/update-snap`   | each of the three Snap! checkouts                |
+| `bin/deploy`        | `~/snapCloud/static/`                            |
+| git hook (see next) | the checkout the hook is installed in           |
+
+`bin/compress` is idempotent — it only re-gzips a file whose source is
+newer than the existing `.gz`. Re-running it costs ~nothing.
+
+## Git hooks for automatic compression
+
+`bin/update-snap` already pre-compresses each Snap! checkout when it
+runs. For deployments that pull Snap! changes outside of `update-snap`
+(e.g. a `git pull` you run by hand, or a webhook-driven update),
+install a `post-merge` / `post-checkout` hook in each Snap! checkout
+so compression always stays in sync with the source files.
+
+### Installing the hook
+
+Run the following **once per checkout** on the server:
+
+```bash
+for repo in \
+    ~/snapCloud/snap \
+    ~/snap-versions/dev \
+    ~/snap-versions/previous; do
+    hook="$repo/.git/hooks/post-merge"
+    cat > "$hook" <<'EOF'
+#!/usr/bin/env bash
+# Re-build .gz siblings whenever the working tree changes.
+set -e
+"$HOME/snapCloud/bin/compress" "$(git rev-parse --show-toplevel)"
+EOF
+    chmod +x "$hook"
+    # `git checkout` (used by update-snap and manual switches) fires
+    # post-checkout, not post-merge — symlink the two so both trigger.
+    ln -sf post-merge "$repo/.git/hooks/post-checkout"
+done
+```
+
+Notes:
+
+- The hook body is identical for every checkout, so it's safe to copy
+  and to re-install if any checkout gets reset.
+- `bin/compress` is idempotent, so leaving the hook installed costs
+  nothing.
+- The `post-checkout` symlink covers `bin/update-snap`, which uses
+  `git checkout <ref>` rather than `git merge`. If your workflow also
+  uses `git rebase`, add a `post-rewrite` symlink the same way.
+- `*.gz` is in the Snap! repo's `.gitignore`, so the generated files
+  never show up in `git status`.
+
+### A matching hook for snapCloud itself
+
+If you want `~/snapCloud/static/` to recompress whenever snapCloud
+itself updates (rather than only on `bin/deploy`), install the same
+hook in `~/snapCloud/`:
+
+```bash
+hook=~/snapCloud/.git/hooks/post-merge
+cat > "$hook" <<'EOF'
+#!/usr/bin/env bash
+set -e
+"$HOME/snapCloud/bin/compress" "$HOME/snapCloud/static"
+EOF
+chmod +x "$hook"
+ln -sf post-merge ~/snapCloud/.git/hooks/post-checkout
+```
+
+### Alternative: `post-receive` for push-to-deploy setups
+
+If a checkout receives pushes directly (i.e. it has its own bare repo
+upstream on the server), install a `post-receive` hook on the bare
+repo's side instead. It needs to find the work tree for the checkout:
+
+```bash
+#!/usr/bin/env bash
+set -e
+"$HOME/snapCloud/bin/compress" /path/to/checkout
+```
+
+Save as `<bare-repo>/hooks/post-receive` and `chmod +x` it.
+
+## Verifying compression is live
+
+After a deploy, sanity-check that nginx is actually serving the
+pre-compressed bytes:
+
+```bash
+curl -sI -H 'Accept-Encoding: gzip' https://snap.berkeley.edu/snap/src/morphic.js \
+    | grep -i 'content-encoding\|content-length'
+```
+
+You should see `content-encoding: gzip` and a `content-length` close to
+the on-disk size of `src/morphic.js.gz` (much smaller than the
+uncompressed `.js`). If the length matches the uncompressed source,
+`gzip_static` did not find the `.gz` — re-run `bin/update-snap` (for a
+Snap! checkout) or `bin/compress ~/snapCloud/static` (for snapCloud)
+to regenerate.
+
+For lapis API responses, expect `content-encoding: gzip` but no
+`content-length` (responses are chunked):
+
+```bash
+curl -sI -H 'Accept-Encoding: gzip' https://snap.berkeley.edu/api/v1/projects \
+    | grep -i 'content-encoding\|transfer-encoding'
+```

--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,10 @@
 # update_tor: wget https://check.torproject.org/torbulkexitlist -O lib/torbulkexitlist
 app: lapis server
 # CSS Compilation
-saas: npx sass --watch static/scss/:static/style/compiled/ --style compressed
+# Drop any pre-compressed .css.gz first so nginx's gzip_static doesn't serve
+# a stale copy after sass rewrites the .css. bin/compress will regenerate
+# them on the next run.
+saas: rm -f static/style/compiled/*.css.gz && npx sass --watch static/scss/:static/style/compiled/ --style compressed
 # db: postgres -D ${PG_DATA_DIR=/var/lib/postgresql/9.5/main}
 # Install maildev with npm i maildev
 # Access sent emails at http://localhost:1080

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The Snap<em>!</em>Cloud is a backend for Snap<i>!</i> that stores only metadata 
 * Bootstrap 5, npm
 
 ## Installation
-See the [INSTALL.md](INSTALL.md) file for installation instructions.
+See the [INSTALL.md](docs/INSTALL.md) file for installation instructions,
+and [DEPLOYMENT.md](docs/DEPLOYMENT.md) for production deploy notes.
 
 ### Live instance
 The Snap!Cloud is currently live at [https://snap.berkeley.edu](https://snap.berkeley.edu). See the API description page at [https://snap.berkeley.edu/static/API](https://cloud.snap.berkeley.edu/static/API).

--- a/bin/compress
+++ b/bin/compress
@@ -65,10 +65,20 @@ compress_dir() {
         return 1
     fi
 
-    local compressed=0 skipped=0 saved_bytes=0
-    local file gz orig_size gz_size
-
+    local files=()
     while IFS= read -r -d '' file; do
+        files+=("$file")
+    done < <(find "$target" \( "${find_expr[@]}" \) -type f \
+                  -not -name '*.gz' -not -name 'sw.js' -print0)
+
+    local total=${#files[@]}
+    local index=0 compressed=0 skipped=0 saved_bytes=0
+    local file gz orig_size gz_size pct
+
+    printf 'compress: %d candidate(s) in %s\n' "$total" "$target"
+
+    for file in "${files[@]}"; do
+        index=$((index + 1))
         gz="${file}.gz"
         if [[ "$force" -eq 0 && -f "$gz" && ! "$file" -nt "$gz" ]]; then
             skipped=$((skipped + 1))
@@ -81,8 +91,10 @@ compress_dir() {
         gz_size=$(wc -c < "$gz")
         saved_bytes=$((saved_bytes + orig_size - gz_size))
         compressed=$((compressed + 1))
-    done < <(find "$target" \( "${find_expr[@]}" \) -type f \
-                  -not -name '*.gz' -not -name 'sw.js' -print0)
+        pct=$(( gz_size * 100 / (orig_size > 0 ? orig_size : 1) ))
+        printf '  [%d/%d] %s  %d → %d bytes (%d%%)\n' \
+            "$index" "$total" "$file" "$orig_size" "$gz_size" "$pct"
+    done
 
     printf 'compress: %d compressed, %d unchanged, %d bytes saved (%s)\n' \
         "$compressed" "$skipped" "$saved_bytes" "$target"

--- a/bin/compress
+++ b/bin/compress
@@ -1,0 +1,93 @@
+#! /usr/bin/env bash
+#
+# Pre-compress static assets with gzip so that nginx can serve them with
+# `gzip_static on` instead of compressing on every request.
+#
+# Each compressible file FOO gets a sibling FOO.gz. The original file is
+# kept so clients that do not advertise `Accept-Encoding: gzip` still work.
+#
+# Usage:
+#   bin/compress PATH [PATH ...]    # compress one or more directories
+#   bin/compress --force PATH       # rewrite every .gz even if up to date
+#
+# Typical server invocations:
+#   bin/compress ~/snapCloud/snap                # main snap release
+#   bin/compress ~/snap-versions/dev             # dev snap
+#   bin/compress ~/snapCloud/static              # snapCloud's own static dir
+#
+# The script is idempotent: an existing .gz is only rewritten if the source
+# is newer (or if --force is passed).
+#
+# HTML files (and sw.js) are intentionally NOT pre-compressed: the nginx
+# Snap! locations use `sub_filter <head>` to inject the cloud-domain meta
+# tag at runtime, and `gzip_static` would serve the .gz before sub_filter
+# can run — silently dropping the substitution.
+
+set -euo pipefail
+
+force=0
+targets=()
+for arg in "$@"; do
+    case "$arg" in
+        -f|--force) force=1 ;;
+        -h|--help)
+            sed -n '2,22p' "$0"
+            exit 0
+            ;;
+        *) targets+=("$arg") ;;
+    esac
+done
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "compress: no target directory given" >&2
+    sed -n '2,22p' "$0" >&2
+    exit 2
+fi
+
+# File extensions worth gzipping. Binary formats (png, jpg, wav, mp3, pdf,
+# gif, ico, ...) are already compressed and would only get bigger.
+# Note: html/htm/sw.js are deliberately excluded — see header comment.
+extensions=(js mjs css xml svg json map txt md ts wasm)
+
+# Build a find expression: -iname '*.js' -o -iname '*.css' ...
+find_expr=()
+for ext in "${extensions[@]}"; do
+    if [[ ${#find_expr[@]} -gt 0 ]]; then
+        find_expr+=( -o )
+    fi
+    find_expr+=( -iname "*.${ext}" )
+done
+
+compress_dir() {
+    local target=$1
+    if [[ ! -d "$target" ]]; then
+        echo "compress: not a directory: $target" >&2
+        return 1
+    fi
+
+    local compressed=0 skipped=0 saved_bytes=0
+    local file gz orig_size gz_size
+
+    while IFS= read -r -d '' file; do
+        gz="${file}.gz"
+        if [[ "$force" -eq 0 && -f "$gz" && ! "$file" -nt "$gz" ]]; then
+            skipped=$((skipped + 1))
+            continue
+        fi
+        # -9 best compression, -k keep original, -n strip name/timestamp
+        # from the gzip header so output is reproducible across runs.
+        gzip -9 -k -n -f "$file"
+        orig_size=$(wc -c < "$file")
+        gz_size=$(wc -c < "$gz")
+        saved_bytes=$((saved_bytes + orig_size - gz_size))
+        compressed=$((compressed + 1))
+    done < <(find "$target" \( "${find_expr[@]}" \) -type f \
+                  -not -name '*.gz' -not -name 'sw.js' -print0)
+
+    printf 'compress: %d compressed, %d unchanged, %d bytes saved (%s)\n' \
+        "$compressed" "$skipped" "$saved_bytes" "$target"
+}
+
+for target in "${targets[@]}"; do
+    compress_dir "$target"
+done

--- a/bin/deploy
+++ b/bin/deploy
@@ -22,6 +22,10 @@ pushd ~/snapCloud/bin/;
 ./deploy-certs
 popd;
 
+# Pre-compress snapCloud's own static assets (CSS/JS/SVG) so nginx can
+# serve them via `gzip_static on` rather than gzipping on every request.
+~/snapCloud/bin/compress ~/snapCloud/static
+
 # ./update-snap
 
 

--- a/bin/prereqs.sh
+++ b/bin/prereqs.sh
@@ -15,7 +15,7 @@ fi
 
 error() {
     print_error "Failed to perform automatic install."
-    print_error "Please follow the instructions for manual install at INSTALL.md."
+    print_error "Please follow the instructions for manual install at docs/INSTALL.md."
     exit 1
 }
 
@@ -59,4 +59,4 @@ apt-get install postgresql postgresql-client -y
 if [ $? -ne 0 ]; then error; fi
 
 print_ok "Prerequisites installed."
-print_ok "Please follow all instructions after 'Setting up the database' in INSTALL.md"
+print_ok "Please follow all instructions after 'Setting up the database' in docs/INSTALL.md"

--- a/bin/setup-macos
+++ b/bin/setup-macos
@@ -62,4 +62,4 @@ print_ok "Setting up postgres database."
 export LAPIS_ENVIRONMENT=development
 bin/lapis-migrate
 
-# print_ok "Please follow all instructions after 'Setting up the database' in INSTALL.md"
+# print_ok "Please follow all instructions after 'Setting up the database' in docs/INSTALL.md"

--- a/bin/update-snap
+++ b/bin/update-snap
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
 base=~/snapCloud;
+compress="$base/bin/compress"
 
 pushd $base/snap/;
 echo "Updating Main Snap! Release"
@@ -10,6 +11,7 @@ snap_release=$(git describe --tags $(git rev-list --tags --max-count=1))
 echo "Checking out Snap! ${snap_release}"
 git checkout $snap_release
 popd;
+"$compress" "$base/snap"
 echo
 echo
 
@@ -22,6 +24,7 @@ snap_release="origin/master"
 echo "Checking out Snap! $snap_release"
 git checkout $snap_release
 popd;
+"$compress" "$base/snap-versions/dev"
 echo
 echo
 
@@ -33,5 +36,6 @@ git fetch origin
 echo "Checking out $snap_release"
 git checkout $snap_release
 popd;
+"$compress" "$base/snap-versions/previous"
 echo
 echo

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -2,7 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.7 (Homebrew)
+
+-- Dumped from database version 16.10 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -735,6 +736,8 @@ ALTER TABLE ONLY public.tokens
 
 
 
+
+
 COPY public.lapis_migrations (name) FROM stdin;
 20190140
 201901291
@@ -759,12 +762,13 @@ COPY public.lapis_migrations (name) FROM stdin;
 2025-06-18:0
 2025-09-04:0
 2026-04-06:0
-2026-04-14:0
 2026-04-06:2
+2026-04-14:0
 2026-04-14:1
 2026-05-04:0
 2026-05-11:0
 \.
+
 
 
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,7 +6,7 @@ development setup see [`INSTALL.md`](./INSTALL.md).
 ## Snap! checkouts on the server
 
 The production server keeps several independent Snap! checkouts. They are
-served from the locations defined in [`nginx.conf.d/snap-ide.conf`](./nginx.conf.d/snap-ide.conf):
+served from the locations defined in [`nginx.conf.d/snap-ide.conf`](../nginx.conf.d/snap-ide.conf):
 
 | Path on disk            | Served at              | Tracks                                  |
 | ----------------------- | ---------------------- | --------------------------------------- |
@@ -24,7 +24,7 @@ text asset.
 ## gzip configuration
 
 Gzip is configured **once**, at the `http { }` level in
-[`nginx.conf`](./nginx.conf):
+[`nginx.conf`](../nginx.conf):
 
 ```nginx
 gzip on;              # on-the-fly compression for dynamic responses

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -258,7 +258,7 @@ $ bin/luarocks-macos build --only-deps --pin snapcloud-dev-0.rockspec
 ## Production Configuration
 
 ### SSL
-The production instance needs SSL to run. See [certs/README.md](certs/README.md) for details on configuring SSL certificates.
+The production instance needs SSL to run. See [certs/README.md](../certs/README.md) for details on configuring SSL certificates.
 
 ### Setting Environment Variables
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -66,6 +66,21 @@ http {
     # http2 on;
     keepalive_timeout 70;
 
+    # gzip — applied to every server/location below unless overridden.
+    # gzip_static prefers a `.gz` sibling produced by bin/compress at
+    # deploy time; gzip on still covers dynamic lapis responses (JSON
+    # from /api/v1/ and HTML from @lapisapp). gzip_min_length skips tiny
+    # responses where compression overhead isn't worth it; lapis
+    # responses larger than ~1 KB — including the big JSON payloads
+    # over 1 MB — get compressed.
+    gzip on;
+    gzip_static on;
+    gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_types *;
+
     # We use a separate server block for each host to serve specific certs.
     server {
         server_name ${{HOSTNAME}} ${{SECONDARY_HOSTNAME}};

--- a/nginx.conf.d/snap-ide.conf
+++ b/nginx.conf.d/snap-ide.conf
@@ -11,9 +11,11 @@ location ~ ^/snap$ {
 }
 
 location /snap/ {
-    gzip on;
-    gzip_min_length 1000;
-    gzip_types *;
+    # gzip / gzip_static are configured at the http {} level in nginx.conf
+    # so they apply to every location. bin/compress (called from
+    # bin/update-snap) writes .gz siblings for js/css/svg/xml/json. HTML
+    # is intentionally NOT pre-compressed so sub_filter below can still
+    # inject the cloud-domain <head> tag on the fly.
     sub_filter <head> $cloud_loc;
     etag on;
     # Disable the access log for all Snap! requests, except the IDE.
@@ -37,9 +39,7 @@ location /snap/ {
 }
 
 location /versions/ {
-    gzip on;
-    gzip_min_length 1000;
-    gzip_types *;
+    # See /snap/ above for gzip / sub_filter notes.
     sub_filter <head> $cloud_loc;
     access_log off;
     etag on;

--- a/start.sh
+++ b/start.sh
@@ -4,5 +4,8 @@ if [[ $1 != "--no-tor" ]]; then
     wget https://check.torproject.org/torbulkexitlist -O lib/torbulkexitlist
 fi
 
+# Drop any pre-compressed .css.gz first so nginx's gzip_static doesn't serve
+# a stale copy after sass rewrites the .css. bin/compress regenerates them.
+rm -f static/style/compiled/*.css.gz
 sass --watch static/scss/:static/style/compiled/ --style compressed &
 authbind --deep lapis server $LAPIS_ENVIRONMENT


### PR DESCRIPTION
## Add gzip pre-compression for Snap! IDE and snapCloud static assets

Sets up automated gzip pre-compression across both the Snap! IDE checkouts and snapCloud's own static assets, enabling nginx to serve pre-compressed files via `gzip_static` instead of compressing on every request. Also centralizes nginx gzip configuration and adds deployment documentation.

## Changes

- **`bin/compress`** (new) — idempotent bash script that writes `.gz` siblings for JS/CSS/SVG/JSON/XML/etc. Intentionally skips `.html` and `sw.js` to preserve `sub_filter` injection for the cloud-domain `<head>` tag
- **`nginx.conf`** — moves gzip config to the `http {}` block so all locations (Snap! IDE, `/static/`, Lapis API) inherit it; adds `gzip_static on` for pre-compressed assets and `gzip on` for dynamic responses (e.g. large JSON payloads from `/api/v1/`)
- **`nginx.conf.d/snap-ide.conf`** — removes now-redundant per-location gzip directives; adds comments explaining the HTML exclusion
- **`bin/update-snap`** — calls `bin/compress` after each of the three Snap! checkout updates (main release, dev, previous)
- **`bin/deploy`** — calls `bin/compress ~/snapCloud/static` after cert renewal to pre-compress snapCloud's own CSS/JS/SVG
- **`DEPLOYMENT.md`** (new) — documents server checkout layout, gzip configuration rationale, when pre-compression runs, and git hook recipes (`post-merge`/`post-checkout`) for keeping `.gz` files in sync across all checkouts
- **`.gitignore`** updates in both repos to exclude generated `.gz` artifacts

## Reviewer Notes

- `gzip_static` requires `ngx_http_gzip_static_module`, which OpenResty (installed by `bin/prereqs.sh`) includes by default
- HTML files are deliberately excluded from pre-compression — `gzip_static` would bypass `sub_filter`, silently dropping the cloud-domain meta tag injection
- `bin/compress` is idempotent; re-running only recompresses files newer than their existing `.gz`

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/hkwCjdJCCGtN/implementations/fPn6g8TTdhWD) | [Guided Review](https://www.superconductor.com/tickets/hkwCjdJCCGtN/implementations/fPn6g8TTdhWD?tab=guided_review)

<!-- created-by-superconductor -->