### PR TITLE
Fix: Handle nil 'queried_user' in forgot-password POST request

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -301,7 +301,9 @@ app:before_filter(function (self)
     elseif self.params.user_id and self.params.user_id ~= '' then
         self.queried_user =
             package.loaded.Users:find({ id = self.params.user_id })
-        self.params.username = self.queried_user.username
+        if self.queried_user then
+            self.params.username = self.queried_user.username
+        end
     end
 
     -- unescape all parameters and JSON-decode them


### PR DESCRIPTION
## Fix: Guard against nil `queried_user` in global before_filter

Prevents a 500 crash when the global before_filter receives a request with a `user_id` that doesn't match any database record. Without this guard, any request carrying a non-existent `user_id` would crash before the route handler even ran.

## Changes

- Add a nil check before accessing `self.queried_user.username` in the global `before_filter`, bringing the `user_id` branch into parity with the `username` branch which already handles nil lookups safely

## Context

This was surfaced by an automated security scanner sending `POST /forgot-password/?user_id=1&hash_check=%25C0` — not a real user action. The legitimate forgot-password form posts to a different URL with a different parameter set and would never trigger this path. However, the bug is real: any request to any route on the site with a stale or non-existent `user_id` would have hit this crash, so the guard is warranted regardless of the source.

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/kFQNnkDtcnzr/implementations/hgnqL8bFCdkg) | [App Preview](https://www.superconductor.com/tickets/kFQNnkDtcnzr/implementations/hgnqL8bFCdkg/preview) | [Guided Review](https://www.superconductor.com/tickets/kFQNnkDtcnzr/implementations/hgnqL8bFCdkg?tab=guided_review)

<!-- created-by-superconductor -->