### PR TITLE
Add a / so /search works on nested routes

### DIFF
--- a/views/layout/navigation_bar.etlua
+++ b/views/layout/navigation_bar.etlua
@@ -38,7 +38,7 @@
         </li>
       </ul>
       <span class="navbar-nav me-auto">
-          <form role="search" action="search">
+          <form role="search" action="/search">
             <div class="input-group min-width">
               <button class="btn btn-sm btn-outline-light" type="submit" aria-label="Search">
                 <i class="fas fa-search" aria-hidden="true"></i>


### PR DESCRIPTION
Surprised we never ran into this! But there are not many nested routes....

I _think_ this only happens for error pages and a few admin routes,
where search would go to the wrong URL.
